### PR TITLE
Allow project root to be used as plugin base folder

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+import InteractiveHtmlBom


### PR DESCRIPTION
With this change, the repository can be directly cloned into the plugin folder without the need of adding a symlink or copying. 