### PR TITLE
Extract PCB outline from footprints additionally

### DIFF
--- a/InteractiveHtmlBom/generate_interactive_bom.py
+++ b/InteractiveHtmlBom/generate_interactive_bom.py
@@ -236,6 +236,16 @@ def parse_edges(pcb):
                     bbox = d.GetBoundingBox()
                 else:
                     bbox.Merge(d.GetBoundingBox())
+    for m in pcb.GetModules():
+        for d in m.GraphicalItems():
+            if d.GetLayer() == pcbnew.Edge_Cuts:
+                parsed_drawing = parse_drawing(d)
+                if(parsed_drawing):
+                    edges.append(parsed_drawing)
+                    if bbox is None:
+                        bbox = d.GetBoundingBox()
+                    else:
+                        bbox.Merge(d.GetBoundingBox())
     if bbox:
         bbox.Normalize()
     return edges, bbox
@@ -436,7 +446,8 @@ def main(pcb, launch_browser=True):
     edges, bbox = parse_edges(pcb)
     if bbox is None:
         msg = 'Please draw pcb outline on the edges ' \
-              'layer before generating BOM.'
+              'layer on sheet or any module before ' \
+              'generating BOM.'
         if is_cli:
             logging.error(msg)
         else:


### PR DESCRIPTION
In PCBs with gold fingers I usually define the PCB outline + gold fingers together in a footprint because they form a unit in my view.
KiCAD won't let you draw on the Edge.Cuts layer in the footprint editor so some text editing is required. The data structures support it without any problems.
This patch gathers PCB edges from all footprints in addition to the PCB itself. As a result the interactive BOM can be generated without adding PCB edges on the PCB sheet if they are already defined in a footprint.

I am aware that this supports a sort of hacky workflow and could understand if you would choose not to merge. However this is what makes InteractiveHtmlBom work out of the box for me. :)