### PR TITLE
make find_pcbnew_window() robust to case

### DIFF
--- a/InteractiveHtmlBom/__init__.py
+++ b/InteractiveHtmlBom/__init__.py
@@ -14,7 +14,7 @@ def check_for_bom_button():
     # https://kicad.mmccoo.com/2017/03/05/adding-your-own-command-buttons-to-the-pcbnew-gui/
     def find_pcbnew_window():
         windows = wx.GetTopLevelWindows()
-        pcbneww = [w for w in windows if "Pcbnew" in w.GetTitle()]
+        pcbneww = [w for w in windows if "pcbnew" in w.GetTitle().lower()]
         if len(pcbneww) != 1:
             return None
         return pcbneww[0]


### PR DESCRIPTION
With some KiCad versions on some systems the pcbnew window goes under the name "PcbNew". Notice the uppercase N.
More info at [https://github.com/MitjaNemec/Kicad_action_plugins/issues/22](https://github.com/MitjaNemec/Kicad_action_plugins/issues/22)
