### PR TITLE
Group adjacent ranges of component refs in the BOM table

### DIFF
--- a/InteractiveHtmlBom/web/ibom.js
+++ b/InteractiveHtmlBom/web/ibom.js
@@ -390,7 +390,28 @@ function populateBomBody() {
     }
     // References
     td = document.createElement("TD");
-    td.innerHTML = highlightFilter(references.map(r => r[0]).join(", "));
+    var groupedRefs = [];
+    references.map(r => {
+        var match = r[0].match(/^(.*?)([0-9]+)$/);
+
+        if (match) {
+          return [match[1], parseInt(match[2]), r[0]];
+        } else {
+          return [r[0], NaN, r[0]];
+        }
+    }).forEach(([prefix, num, r]) => {
+      if (groupedRefs.length > 0) {
+        var last = groupedRefs[groupedRefs.length-1];
+        if (last[0] === prefix && last[1] === num-1) {
+          last[1] = num;
+          last[3] = r;
+          return;
+        }
+      }
+      groupedRefs.push([prefix, num, r, r]);
+    });
+
+    td.innerHTML = highlightFilter(groupedRefs.map(([prefix, num, r1, r2]) => (r1 === r2 ? r1 : r1+"-"+r2)).join(", "));
     tr.appendChild(td);
     // Extra fields
     for (var i in config.extra_fields) {


### PR DESCRIPTION
Resolves #20.

The component lookup box behaves just as before.

If you enter a ref that isn't from the end of a range into the filter box, it will still match the row, but with no highlight. I can improve this behaviour if you wish (highlight the range? expand out the relevant range and highlight the relevant part?)

---

From the motherboard demo:

### After:

![2019-04-15-021708_948x828_scrot](https://user-images.githubusercontent.com/691552/56094196-9df4b700-5f25-11e9-9163-9320f30180b9.png)

### Before:

![2019-04-15-021655_958x509_scrot](https://user-images.githubusercontent.com/691552/56094195-9df4b700-5f25-11e9-824a-cbe9c9410942.png)

