### PR TITLE
Fix parsing escaped quotes in SExpr

### DIFF
--- a/InteractiveHtmlBom/ecad/kicad_extra/sexpressions.py
+++ b/InteractiveHtmlBom/ecad/kicad_extra/sexpressions.py
@@ -4,7 +4,7 @@ term_regex = r'''(?mx)
     \s*(?:
         (?P<open>\()|
         (?P<close>\))|
-        (?P<sq>"[^"]*")|
+        (?P<sq>"(?:\\"|[^"])*")|
         (?P<s>[^(^)\s]+)
        )'''
 pattern = re.compile(term_regex)
@@ -23,7 +23,7 @@ def parse_sexpression(sexpression):
             tmp, out = out, stack.pop(-1)
             out.append(tmp)
         elif term == 'sq':
-            out.append(value[1:-1])
+            out.append(value[1:-1].replace('\\"', '"'))
         elif term == 's':
             out.append(value)
         else:


### PR DESCRIPTION
Parsing KiCad SExpr files with quotes in strings, which KiCad represents as `\"`, currently fails with "Trouble with nesting of brackets", hitting an assert at `ecad/kicad_extra/sexpressions.py:22`.

Code after this change may still have problems with backslashes in SExprs, but those are likely much rarer and would require more than a simple change to deal with.