### PR TITLE
Avoid X11 dependency using an environment variable.

### DIFF
--- a/InteractiveHtmlBom/generate_interactive_bom.py
+++ b/InteractiveHtmlBom/generate_interactive_bom.py
@@ -27,11 +27,12 @@ if __name__ == "__main__":
     from .ecad import get_parser_by_extension
     from .version import version
 
-    delay_wx = False
-    if os.environ.get('INTERACTIVE_HTML_NO_X11') == 'True':
-        # Create the app only if we are going to create the dialog
-        delay_wx = True
-    if not delay_wx:
+    create_wx_app = False
+    if 'DISPLAY' in os.environ:
+        display = os.environ['DISPLAY']
+        if len(display) > 0:
+            create_wx_app = True
+    if create_wx_app:
         import wx
         app = wx.App()
 
@@ -51,9 +52,9 @@ if __name__ == "__main__":
     logger = ibom.Logger(cli=True)
     parser = get_parser_by_extension(os.path.abspath(args.file), config, logger)
     if args.show_dialog:
-        if delay_wx:
-            import wx
-            app = wx.App()
+        if not create_wx_app:
+            print("Can not show dialog when INTERACTIVE_HTML_BOM_NO_DISPLAY is set.")
+            exit(1)
         ibom.run_with_dialog(parser, config, logger)
     else:
         config.set_from_args(args)

--- a/InteractiveHtmlBom/generate_interactive_bom.py
+++ b/InteractiveHtmlBom/generate_interactive_bom.py
@@ -27,11 +27,7 @@ if __name__ == "__main__":
     from .ecad import get_parser_by_extension
     from .version import version
 
-    create_wx_app = False
-    if 'DISPLAY' in os.environ:
-        display = os.environ['DISPLAY']
-        if len(display) > 0:
-            create_wx_app = True
+    create_wx_app = 'INTERACTIVE_HTML_BOM_NO_DISPLAY' not in os.environ
     if create_wx_app:
         import wx
         app = wx.App()
@@ -53,7 +49,7 @@ if __name__ == "__main__":
     parser = get_parser_by_extension(os.path.abspath(args.file), config, logger)
     if args.show_dialog:
         if not create_wx_app:
-            print("Can not show dialog when DISPLAY isn't defined.")
+            print("Can not show dialog when INTERACTIVE_HTML_BOM_NO_DISPLAY is set.")
             exit(1)
         ibom.run_with_dialog(parser, config, logger)
     else:

--- a/InteractiveHtmlBom/generate_interactive_bom.py
+++ b/InteractiveHtmlBom/generate_interactive_bom.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     parser = get_parser_by_extension(os.path.abspath(args.file), config, logger)
     if args.show_dialog:
         if not create_wx_app:
-            print("Can not show dialog when INTERACTIVE_HTML_BOM_NO_DISPLAY is set.")
+            print("Can not show dialog when DISPLAY isn't defined.")
             exit(1)
         ibom.run_with_dialog(parser, config, logger)
     else:

--- a/InteractiveHtmlBom/generate_interactive_bom.py
+++ b/InteractiveHtmlBom/generate_interactive_bom.py
@@ -4,8 +4,6 @@ import argparse
 import os
 import sys
 
-import wx
-
 
 # python 2 and 3 compatibility hack
 def to_utf(s):
@@ -29,7 +27,13 @@ if __name__ == "__main__":
     from .ecad import get_parser_by_extension
     from .version import version
 
-    app = wx.App()
+    delay_wx = False
+    if os.environ.get('INTERACTIVE_HTML_NO_X11') == 'True':
+        # Create the app only if we are going to create the dialog
+        delay_wx = True
+    if not delay_wx:
+        import wx
+        app = wx.App()
 
     parser = argparse.ArgumentParser(
             description='KiCad InteractiveHtmlBom plugin CLI.',
@@ -47,6 +51,9 @@ if __name__ == "__main__":
     logger = ibom.Logger(cli=True)
     parser = get_parser_by_extension(os.path.abspath(args.file), config, logger)
     if args.show_dialog:
+        if delay_wx:
+            import wx
+            app = wx.App()
         ibom.run_with_dialog(parser, config, logger)
     else:
         config.set_from_args(args)


### PR DESCRIPTION
This patch delays the wx.App() initialization only if the INTERACTIVE_HTML_NO_X11 is defined to "True". Otherwise the initialization is done, even if no dialog is used.

See INTI-CMNB/InteractiveHtmlBom@058ade94eb2934c4e1ec1d9d8ab54ff51d937f5b