### PR TITLE
Make generate_interactive_bom.py executable on UNIX

### DIFF
--- a/InteractiveHtmlBom/generate_interactive_bom.py
+++ b/InteractiveHtmlBom/generate_interactive_bom.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 from __future__ import absolute_import
 
 import argparse


### PR DESCRIPTION
The Python script needs execution flags and a shebang line.
This allows executing the script without explicitly invoking Python.
