### PR TITLE
Middle button panning

### DIFF
--- a/InteractiveHtmlBom/web/render.js
+++ b/InteractiveHtmlBom/web/render.js
@@ -671,7 +671,7 @@ function bboxHitScan(layer, x, y) {
 }
 
 function handlePointerDown(e, layerdict) {
-  if (e.button != 0) {
+  if (e.button != 0 && e.button != 1) {
     return;
   }
   e.preventDefault();


### PR DESCRIPTION
Thank you for creating and maintaining this extremely useful plugin. 

Pretty much an extension of #22. Is there a particular reason to limit the panning behavior as left-button based opposed to middle-button as in Pcbnew?

I think it would make sense to support both: left-button for touch screen devices, and middle-button for those still using their mouse. With muscle memory I find myself trying to use the middle-button to pan as I would in Pcbnew and Eeshema. 

Mozilla docs for [MouseEvent.button](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button) show that it's as simple as allowing 0 and 2 to pass.