### PR TITLE
Return error level != 0 for parsing errors.

### DIFF
--- a/InteractiveHtmlBom/core/ibom.py
+++ b/InteractiveHtmlBom/core/ibom.py
@@ -295,14 +295,14 @@ def main(parser, config, logger):
 
     if extra_fields is None and need_extra_fields:
         logger.error('Failed parsing %s' % config.netlist_file)
-        return
+        return False
 
     extra_fields = extra_fields[1] if extra_fields else None
 
     pcbdata, components = parser.parse()
     if not pcbdata or not components:
         logger.error('Parsing failed.')
-        return
+        return False
 
     pcbdata["bom"] = generate_bom(components, config, extra_fields)
     pcbdata["ibom_version"] = config.version
@@ -313,6 +313,8 @@ def main(parser, config, logger):
     if config.open_browser:
         logger.info("Opening file in browser")
         open_file(bom_file)
+
+    return True
 
 
 def run_with_dialog(parser, config, logger):

--- a/InteractiveHtmlBom/core/ibom.py
+++ b/InteractiveHtmlBom/core/ibom.py
@@ -14,6 +14,7 @@ from . import units
 from .config import Config
 from ..dialog import SettingsDialog
 from ..ecad.common import EcadParser, Component
+from ..errors import ParsingException
 
 
 class Logger(object):
@@ -294,15 +295,13 @@ def main(parser, config, logger):
         need_extra_fields = False
 
     if extra_fields is None and need_extra_fields:
-        logger.error('Failed parsing %s' % config.netlist_file)
-        return False
+        raise ParsingException('Failed parsing %s' % config.netlist_file)
 
     extra_fields = extra_fields[1] if extra_fields else None
 
     pcbdata, components = parser.parse()
     if not pcbdata or not components:
-        logger.error('Parsing failed.')
-        return False
+        raise ParsingException('Parsing failed.')
 
     pcbdata["bom"] = generate_bom(components, config, extra_fields)
     pcbdata["ibom_version"] = config.version
@@ -313,8 +312,6 @@ def main(parser, config, logger):
     if config.open_browser:
         logger.info("Opening file in browser")
         open_file(bom_file)
-
-    return True
 
 
 def run_with_dialog(parser, config, logger):

--- a/InteractiveHtmlBom/ecad/kicad.py
+++ b/InteractiveHtmlBom/ecad/kicad.py
@@ -515,6 +515,7 @@ class InteractiveHtmlBomPlugin(pcbnew.ActionPlugin, object):
 
     def Run(self):
         from ..version import version
+        from ..errors import ParsingException
         self.version = version
         config = Config(self.version)
         board = pcbnew.GetBoard()
@@ -526,4 +527,7 @@ class InteractiveHtmlBomPlugin(pcbnew.ActionPlugin, object):
             return
 
         parser = PcbnewParser(pcb_file_name, config, logger, board)
-        ibom.run_with_dialog(parser, config, logger)
+        try:
+            ibom.run_with_dialog(parser, config, logger)
+        except ParsingException as e:
+            logger.error(str(e))

--- a/InteractiveHtmlBom/errors.py
+++ b/InteractiveHtmlBom/errors.py
@@ -1,12 +1,16 @@
-from sys import exit
+import sys
 
-ERROR_PARSE = 3
-ERROR_FILE_NOT_FOUND = 4
-ERROR_NO_DISPLAY = 5
+
+class ExitCodes():
+    ERROR_PARSE = 3
+    ERROR_FILE_NOT_FOUND = 4
+    ERROR_NO_DISPLAY = 5
+
 
 class ParsingException(Exception):
     pass
 
+
 def exit_error(logger, code, err):
     logger.error(err)
-    exit(code)
+    sys.exit(code)

--- a/InteractiveHtmlBom/errors.py
+++ b/InteractiveHtmlBom/errors.py
@@ -1,0 +1,12 @@
+from sys import exit
+
+ERROR_PARSE = 3
+ERROR_FILE_NOT_FOUND = 4
+ERROR_NO_DISPLAY = 5
+
+class ParsingException(Exception):
+    pass
+
+def exit_error(logger, code, err):
+    logger.error(err)
+    exit(code)

--- a/InteractiveHtmlBom/generate_interactive_bom.py
+++ b/InteractiveHtmlBom/generate_interactive_bom.py
@@ -26,8 +26,7 @@ if __name__ == "__main__":
     from InteractiveHtmlBom.core.config import Config
     from InteractiveHtmlBom.ecad import get_parser_by_extension
     from InteractiveHtmlBom.version import version
-    from InteractiveHtmlBom.errors import (ERROR_PARSE, ERROR_FILE_NOT_FOUND,
-                                          ERROR_NO_DISPLAY, ParsingException,
+    from InteractiveHtmlBom.errors import (ExitCodes, ParsingException,
                                           exit_error)
 
     create_wx_app = 'INTERACTIVE_HTML_BOM_NO_DISPLAY' not in os.environ
@@ -46,21 +45,21 @@ if __name__ == "__main__":
     args = parser.parse_args()
     logger = ibom.Logger(cli=True)
     if not os.path.isfile(args.file):
-        exit_error(logger, ERROR_FILE_NOT_FOUND,
+        exit_error(logger, ExitCodes.ERROR_FILE_NOT_FOUND,
                    "File %s does not exist." % args.file)
     print("Loading %s" % args.file)
     parser = get_parser_by_extension(os.path.abspath(args.file), config, logger)
     if args.show_dialog:
         if not create_wx_app:
-            exit_error(logger, ERROR_NO_DISPLAY, "Can not show dialog when "
+            exit_error(logger, ExitCodes.ERROR_NO_DISPLAY, "Can not show dialog when "
                        "INTERACTIVE_HTML_BOM_NO_DISPLAY is set.")
         try:
             ibom.run_with_dialog(parser, config, logger)
         except ParsingException as e:
-            exit_error(logger, ERROR_PARSE, e)
+            exit_error(logger, ExitCodes.ERROR_PARSE, e)
     else:
         config.set_from_args(args)
         try:
             ibom.main(parser, config, logger)
         except ParsingException as e:
-            exit_error(logger, ERROR_PARSE, e)
+            exit_error(logger, ExitCodes.ERROR_PARSE, str(e))

--- a/InteractiveHtmlBom/generate_interactive_bom.py
+++ b/InteractiveHtmlBom/generate_interactive_bom.py
@@ -54,4 +54,5 @@ if __name__ == "__main__":
         ibom.run_with_dialog(parser, config, logger)
     else:
         config.set_from_args(args)
-        ibom.main(parser, config, logger)
+        if not ibom.main(parser, config, logger):
+            exit(1)


### PR DESCRIPTION
When the command line script fails to parse the PCB we must indicate it
using an error level != 0.
A simple test PCB to reproduce it is:

```
(kicad_pcb (version 20171130) (host pcbnew 5.1.5+dfsg1-2~bpo10+1))
```

Also note that returning 1 is confusing because this is the value returned for unhandled exceptions.
The value of 2 is used by argparse.
IMHO the script should return 3, 4 and 5 for the 3 different errors that is returning 1.
I can do a PR for this if you want.