### PR TITLE
Fix KiCad Nightly custom pad shapes

### DIFF
--- a/InteractiveHtmlBom/ecad/kicad.py
+++ b/InteractiveHtmlBom/ecad/kicad.py
@@ -261,7 +261,11 @@ class PcbnewParser(EcadParser):
             "shape": shape
         }
         if shape == "custom":
-            polygon_set = pad.GetCustomShapeAsPolygon()
+            if hasattr(pad, "GetCustomShapeAsPolygon"):
+                polygon_set = pad.GetCustomShapeAsPolygon()
+            else: # KiCad Nightly has removed "GetCustomShapeAsPolygon"
+                polygon_set = pcbnew.SHAPE_POLY_SET()
+                pad.MergePrimitivesAsPolygon(polygon_set)
             if polygon_set.HasHoles():
                 self.logger.warn('Detected holes in custom pad polygons')
             if polygon_set.IsSelfIntersecting():


### PR DESCRIPTION
I hit an issue with running this plugin on some KiCad Nightly projects.
It looks like KiCad nightly has removed the `GetCustomShapeAsPolygon()` attribute.

Looking through the python layer it appears it's easy to fix by using creating a `SHAPE_POLY_SET` and calling `MergePrimitivesAsPolygon()`

https://docs.kicad-pcb.org/doxygen-python/pcbnew_8py_source.html#l09948
```python
     # GetCustomShapeAsPolygon() is the old accessor to get custom shapes
     def GetCustomShapeAsPolygon(self):
         polygon_set = SHAPE_POLY_SET()
         self.MergePrimitivesAsPolygon(polygon_set)
         return polygon_set
```