### PR TITLE
Include board_variant_field in the list of needed extra fields.

### DIFF
--- a/InteractiveHtmlBom/core/ibom.py
+++ b/InteractiveHtmlBom/core/ibom.py
@@ -283,6 +283,7 @@ def main(parser, config, logger):
     need_extra_fields = (config.extra_fields or
                          config.board_variant_whitelist or
                          config.board_variant_blacklist or
+                         config.board_variant_field or
                          config.dnp_field)
 
     if not config.netlist_file and need_extra_fields:


### PR DESCRIPTION
Otherwise we force the user to add it as a visible column using --extra-fields

BTW: Do you know about any open project using this variant scheme?