### PR TITLE
Rename pad type enum values for KiCad 5.99 (#187)

### DIFF
--- a/InteractiveHtmlBom/ecad/kicad.py
+++ b/InteractiveHtmlBom/ecad/kicad.py
@@ -274,8 +274,8 @@ class PcbnewParser(EcadParser):
         if shape == "chamfrect":
             pad_dict["chamfpos"] = pad.GetChamferPositions()
             pad_dict["chamfratio"] = pad.GetChamferRectRatio()
-        if (pad.GetAttribute() == pcbnew.PAD_ATTRIB_STANDARD or
-            pad.GetAttribute() == pcbnew.PAD_ATTRIB_HOLE_NOT_PLATED):
+        if (pad.GetAttribute() == pcbnew.PAD_ATTRIB_PTH or
+            pad.GetAttribute() == pcbnew.PAD_ATTRIB_NPTH):
             pad_dict["type"] = "th"
             pad_dict["drillshape"] = {
                 pcbnew.PAD_DRILL_SHAPE_CIRCLE: "circle",


### PR DESCRIPTION
Probably needs some checking to not break with non-nightly versions.

Ref:
- [KiCad commit](https://gitlab.com/kicad/code/kicad/-/commit/bf3cb0b1d08335df86f481f3eb6ee28a2c35850e)
- [Doxygen](https://docs.kicad-pcb.org/doxygen/pad__shapes_8h.html#aeefc2b530777150717721ad14319875c)