### PR TITLE
Work-in-progress: Centroid file parser

### DIFF
--- a/InteractiveHtmlBom/centroid2pcbdata.py
+++ b/InteractiveHtmlBom/centroid2pcbdata.py
@@ -1,0 +1,55 @@
+import json
+import argparse
+from ecad.generic import GenericCentroidParser
+from version import version
+
+import os
+import sys
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description='Parse centroid file')
+    parser.add_argument('-i',
+                        '--input',
+                        metavar='board.xy',
+                        type=str,
+                        required=True,
+                        help='Input centroid file')
+    parser.add_argument('-W',
+                        '--width',
+                        metavar='W',
+                        type=float,
+                        required=True,
+                        help='Width of image, in mm')
+    parser.add_argument('-H',
+                        '--height',
+                        metavar='H',
+                        type=float,
+                        required=True,
+                        help='Height of image, in mm')
+    parser.add_argument(
+        '-M',
+        '--mpp',
+        metavar='M',
+        type=float,
+        required=True,
+        help='micrometer per pixel of photorealistic PCB images')
+    parser.add_argument('-o',
+                        '--output',
+                        metavar='pcbdata.json',
+                        type=str,
+                        required=True,
+                        help='Output pcbdata file')
+
+    args = parser.parse_args()
+
+    config = None
+    LOGGER = None
+    centroid_file = GenericCentroidParser(args.input, config, LOGGER,
+                                          args.width, args.height, args.mpp)
+
+    pcbdata, components = centroid_file.parse()
+    pcbdata['ibom_version'] = version
+
+    with open(args.output, 'w') as f:
+        json.dump(pcbdata, f, indent=2)

--- a/InteractiveHtmlBom/ecad/__init__.py
+++ b/InteractiveHtmlBom/ecad/__init__.py
@@ -7,6 +7,8 @@ def get_parser_by_extension(file_name, config, logger):
         return get_kicad_parser(file_name, config, logger)
     elif ext == '.json':
         return get_easyeda_parser(file_name, config, logger)
+    elif ext == '.xy':
+        return get_generic_parser(file_name, config, logger)
     else:
         return None
 
@@ -19,3 +21,7 @@ def get_kicad_parser(file_name, config, logger, board=None):
 def get_easyeda_parser(file_name, config, logger):
     from .easyeda import EasyEdaParser
     return EasyEdaParser(file_name, config, logger)
+
+def get_generic_parser(file_name, config, logger):
+    from .generic import GenericCentroidParser
+    return GenericCentroidParser(file_name, config, logger)

--- a/InteractiveHtmlBom/ecad/generic.py
+++ b/InteractiveHtmlBom/ecad/generic.py
@@ -1,0 +1,201 @@
+import os
+import sys
+from datetime import datetime
+import csv
+import sqlite3
+
+from .common import EcadParser, Component
+
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    string_types = str
+else:
+    string_types = basestring
+
+
+class GenericCentroidParser(EcadParser):
+    ''' Generic centroid file parser '''
+
+    def __init__(self,
+                 file_name,
+                 config,
+                 logger,
+                 width=0.,
+                 height=0.,
+                 mpp=25.4 / 600):
+        # type: (GenericCentroidParser, str, Config, float, float, float)
+
+        EcadParser.__init__(self, file_name, config, logger)
+        self.width = width
+        self.height = height
+        self.mpp = mpp
+        self.bbox_size = 0.1 * 25.4 / self.mpp
+
+        self.components = None
+        self.modules = None
+        self.silkscreen = None
+        self.bom = None
+
+        self.conn = None
+
+    def parse_xy(self):
+        ''' Parse the centroid file '''
+
+        self.conn = sqlite3.connect(':memory:')
+        self.conn.row_factory = sqlite3.Row
+
+        self.conn.execute('''CREATE TABLE xy(refdes STRING PRIMARY KEY,
+               x FLOAT, y FLOAT, angle FLOAT, side STRING)''')
+        self.conn.execute('''CREATE TABLE bom(refdes STRING PRIMARY KEY,
+               footprint STRING, value STRING, side STRING)''')
+
+        self.conn.commit()
+
+        with open(self.file_name, 'r') as f:
+            reader = csv.reader(f)
+            for row in reader:
+                # Skip all comments
+                if row[0][0] == '#':
+                    continue
+
+                # Parse cells
+                refdes = row[0]
+                description = row[1]
+                value = row[2]
+                rotation = float(row[5])
+                coord_x = float(row[3]) / self.mpp
+
+                if row[6] == 'top':
+                    top_or_bottom = 'F'
+                    # Centroid file coordinates' origin is at bottom-left,
+                    # but raster images have origin at top-left.
+                    coord_y = (self.height - float(row[4])) / self.mpp
+                else:
+                    top_or_bottom = 'B'
+                    coord_y = float(row[4]) / self.mpp
+                    # Assuming the back-side PCB rendering is vertically flipped,
+                    # so no need to flip here.
+
+                # Append to in-memory database
+                self.conn.execute('INSERT INTO bom VALUES (?,?,?,?)',
+                                  (refdes, description, value, top_or_bottom))
+
+                self.conn.execute(
+                    'INSERT INTO xy VALUES (?,?,?,?,?)',
+                    (refdes, coord_x, coord_y, rotation, top_or_bottom))
+
+            self.conn.commit()
+
+    def get_bom(self):
+        ''' Create the bill of materials. '''
+        self.bom = {'B': [], 'F': [], 'both': [], 'skipped': []}
+
+        for row in self.conn.execute(
+                '''SELECT footprint, value, side, count(*) AS qty FROM bom
+                   GROUP BY side, footprint, value'''):
+            bom_group = [
+                row['qty'],
+                str(row['value']),
+                str(row['footprint']),
+                [[str(r['refdes']), r['id']] for r in self.conn.execute(
+                    '''SELECT bom.refdes, xy.rowid - 1 AS id FROM bom, xy
+                     WHERE bom.refdes = xy.refdes AND
+                     footprint=? AND value=?''', (row['footprint'],
+                                                  row['value']))], []
+            ]
+
+            self.bom['both'].append(bom_group)
+            self.bom[row['side']].append(bom_group)
+
+    def get_components(self):
+        ''' Create a list of components '''
+        self.components = []
+
+        for row in self.conn.execute(
+                'SELECT refdes, footprint, value, side FROM bom'):
+            self.components.append(
+                Component(row['refdes'], str(row['value']),
+                          str(row['footprint']), str(row['side'])))
+
+    def get_modules(self):
+        ''' Create a list of modules. '''
+        self.modules = []
+
+        for row in self.conn.execute('SELECT refdes, x, y, side FROM xy'):
+            self.modules.append({
+                'center': [row['x'], row['y']],
+                'bbox': {
+                    'angle': 0,
+                    'pos': [row['x'], row['y']],
+                    'relpos': [self.bbox_size * -0.5, self.bbox_size * -0.5],
+                    'size': [self.bbox_size, self.bbox_size],
+                },
+                'pads': [],
+                'drawings': [],
+                'layer': row['side'],
+                'ref': str(row['refdes']),
+            })
+
+    def get_background(self):
+        ''' Create the link to the photorealistic rendering of PCBs in the background. '''
+        self.silkscreen = dict(F=[], B=[])
+
+        prefix = os.path.splitext(self.file_name)[0]
+
+        self.silkscreen['F'].append({
+            'start': [0, 0],
+            'type': 'url',
+            'url': prefix + '-front.png'
+        })
+
+        self.silkscreen['B'].append({
+            'start': [0, 0],
+            'type': 'url',
+            'url': prefix + '-back.png'
+        })
+
+    def parse(self):
+        ''' Parse the centroid file and return the pcbdata and components '''
+
+        self.get_background()
+        self.parse_xy()
+        if self.width <= 0 or self.height <= 0:
+            self.logger.warn(
+                'Missing PCB dimensions in millimeter. Component positions will be inaccurate.'
+            )
+
+        self.get_bom()
+        self.get_modules()
+
+        title = os.path.basename(self.file_name)
+        date = datetime.fromtimestamp(os.path.getmtime(
+            self.file_name)).strftime('%Y-%m-%d')
+
+        pcbdata = {
+            'edges_bbox': {
+                'minx': 0,
+                'miny': 0,
+                'maxx': self.width / self.mpp,
+                'maxy': self.height / self.mpp
+            },
+            'edges': [],
+            'silkscreen': self.silkscreen,
+            'fabrication': {
+                'F': [],
+                'B': [],
+            },
+            'modules': self.modules,
+            'metadata': {
+                'title': title,
+                'company': '',
+                'revision': '',
+                'date': date
+            },
+            'bom': self.bom,
+            'font_data': {}
+        }
+
+        self.get_components()
+
+        return pcbdata, self.components

--- a/InteractiveHtmlBom/web/render.js
+++ b/InteractiveHtmlBom/web/render.js
@@ -356,6 +356,21 @@ function drawModules(canvas, layer, scalefactor, highlight) {
   }
 }
 
+var image_cache = {};
+
+function drawImage(ctx, d) {
+    if (d.url in image_cache) {
+        ctx.drawImage(image_cache[d.url], d.start[0], d.start[1]);
+        return;
+    }
+
+    image_cache[d.url] = new Image();
+    image_cache[d.url].onload = function() {
+        ctx.drawImage(image_cache[d.url], d.start[0], d.start[1]);
+    };
+    image_cache[d.url].src = d.url;
+}
+
 function drawBgLayer(layername, canvas, layer, scalefactor, edgeColor, polygonColor, textColor) {
   var ctx = canvas.getContext("2d");
   for (var d of pcbdata[layername][layer]) {
@@ -363,6 +378,8 @@ function drawBgLayer(layername, canvas, layer, scalefactor, edgeColor, polygonCo
       drawedge(ctx, scalefactor, d, edgeColor);
     } else if (d.type == "polygon") {
       drawPolygonShape(ctx, d, polygonColor);
+    } else if (d.type == "url") {
+        drawImage(ctx, d);
     } else {
       drawtext(ctx, d, textColor, layer == "B");
     }


### PR DESCRIPTION
**Generic Centroid parser**
    
This patch introduces the GenericCentroidParser class to process the PCB pick-n-place / centroid file. This cripples the script
`generate_interactive_bom.py`, so users are advised to invoke the `centroid2pcbdata.py` instead.

The input centroid file follows the following pattern:
```csv    
# PcbXY Version 1.0
# Date: Fri 02 Oct 2020 05:39:00 AM GMT UTC
# Author: author
# Title: (unknown) - PCB X-Y
# RefDes, Description, Value, X, Y, rotation, top/bottom
# X,Y in mm.  rotation in degrees.
# --------------------------------------------
CR1,"diode-bridge-kbp2g.fp","Bridge_Rect",121.92,85.72,90,top
C19,"0603","0.1uF/16v",100.33,66.04,0,bottom
C6,"0805","10uF/16v",24.77,78.11,180,top
pad4,"hole-155mil.fp","hole-155",133.35,82.55,0,top
C5,"0603","1uF/16v",24.13,85.09,180,top
...
```

The command `generate_interactive_bom.py file.xy` produces the HTML with a complete list of components on front and back side. However, the graphical view of the PCBs are empty because of missing image data plus size information.
    
A script `centroid2pcbdata.py` is provided to assist users to convert a centroid file to a valid json-serialized pcbdata object:
    
```
    usage: centroid2pcbdata.py [-h] [-i board.xy] [-o pcbdata.json] [-W M] [-H N]
    
    Parse centroid file
    
    optional arguments:
      -h, --help            show this help message and exit
      -i board.xy, --input board.xy
                            Input centroid file
      -o pcbdata.json, --output pcbdata.json
                            Output pcbdata file
      -W M, --width M       Width of image, in mm
      -H N, --height N      Height of image, in mm
```

---

**Photorealistic PCB rendering on back side**
    
    A UX breaking change is introduced to the render.js script, where the back side canvas is rotated by 180 degree, and without any horizontal flip.
    
Such change is necessary because the back side rendering of the PCB is already flipped horizontally.

Here, the photorealistic rendering of the PCB is assumed to be exported by the PCB software as 'basename-front.png', 'basename-back.png' at a specific millimeter-per-pixel scale. The absolute coordinate of each component, as defined in the centroid file (basename.xy), should match the corresponding rendered element of the PCB.
