### PR TITLE
#199 Use new variable to avoid utf-8 confusion

### DIFF
--- a/InteractiveHtmlBom/core/ibom.py
+++ b/InteractiveHtmlBom/core/ibom.py
@@ -127,8 +127,8 @@ def generate_bom(pcb_footprints, config, extra_data):
         extras = []
         if config.extra_fields:
             if f.ref in extra_data:
-                extras = [extra_data[f.ref].get(f, '')
-                          for f in config.extra_fields]
+                extras = [extra_data[f.ref].get(ef,'')
+                            for ef in config.extra_fields]
             else:
                 # Some components are on pcb but not in schematic data.
                 # Show a warning about possibly outdated netlist/xml file.


### PR DESCRIPTION
Closes #199 by using new variable name for extra field ef to avoid utf-8 trap.

Signed-off-by: Tisham Dhar <whatnickd@gmail.com>