### PR TITLE
Attempt at a fix for issue #176

### DIFF
--- a/InteractiveHtmlBom/web/ibom.css
+++ b/InteractiveHtmlBom/web/ibom.css
@@ -2,8 +2,12 @@
   --pcb-edge-color: black;
   --pad-color: #878787;
   --pad-color-highlight: #D04040;
+  --pad-color-highlight-both: #D0D040;
+  --pad-color-highlight-darkened: #40D040;
   --pin1-outline-color: #ffb629;
   --pin1-outline-color-highlight: #b4ff03;
+  --pin1-outline-color-highlight-both: #b4ff03;
+  --pin1-outline-color-highlight-darkened: #b4ff03;
   --silkscreen-edge-color: #aa4;
   --silkscreen-polygon-color: #4aa;
   --silkscreen-text-color: #4aa;

--- a/InteractiveHtmlBom/web/ibom.js
+++ b/InteractiveHtmlBom/web/ibom.js
@@ -10,6 +10,7 @@ var currentHighlightedRowId;
 var highlightHandlers = [];
 var footprintIndexToHandler = {};
 var netsToHandler = {};
+var darkenedFootprints = new Set();
 var highlightedFootprints = [];
 var highlightedNet = null;
 var lastClicked;
@@ -164,6 +165,10 @@ function createCheckboxChangeHandler(checkbox, references, row) {
       }
       if (darkenWhenChecked) {
         row.classList.add("checked");
+        for(var ref of references) {
+          darkenedFootprints.add(ref[1]);
+        }
+        drawHighlights();
       }
       eventArgs.state = 'checked';
     } else {
@@ -173,6 +178,10 @@ function createCheckboxChangeHandler(checkbox, references, row) {
       }
       if (darkenWhenChecked) {
         row.classList.remove("checked");
+        for(var ref of references) {
+          darkenedFootprints.delete(ref[1]);
+        }
+        drawHighlights();
       }
       eventArgs.state = 'unchecked';
     }
@@ -423,6 +432,7 @@ function populateBomBody() {
     bom.removeChild(bom.firstChild);
   }
   highlightHandlers = [];
+  darkenedFootprints.clear();
   footprintIndexToHandler = {};
   netsToHandler = {};
   currentHighlightedRowId = null;
@@ -492,6 +502,9 @@ function populateBomBody() {
           setBomCheckboxState(checkbox, input, references);
           if (input.checked && settings.darkenWhenChecked == checkbox) {
             tr.classList.add("checked");
+            for(var ref of references) {
+              darkenedFootprints.add(ref[1]);
+            }
           }
           td.appendChild(input);
           tr.appendChild(td);

--- a/InteractiveHtmlBom/web/render.js
+++ b/InteractiveHtmlBom/web/render.js
@@ -342,16 +342,34 @@ function drawFootprints(canvas, layer, scalefactor, highlight) {
   ctx.lineWidth = 3 / scalefactor;
   var style = getComputedStyle(topmostdiv);
   var padcolor = style.getPropertyValue('--pad-color');
+  var highlightedPadColor = style.getPropertyValue('--pad-color-highlight');
+  var darkenedPadColor = style.getPropertyValue('--pad-color-highlight-darkened');
+  var bothPadColor = style.getPropertyValue('--pad-color-highlight-both');
   var outlinecolor = style.getPropertyValue('--pin1-outline-color');
-  if (highlight) {
-    padcolor = style.getPropertyValue('--pad-color-highlight');
-    outlinecolor = style.getPropertyValue('--pin1-outline-color-highlight');
-  }
+  var highlightedOutlinecolor = style.getPropertyValue('--pin1-outline-color-highlight');
+  var darkenedOutlinecolor = style.getPropertyValue('--pin1-outline-color-highlight-darkened');
+  var bothOutlinecolor = style.getPropertyValue('--pin1-outline-highlight-both');
+
   for (var i = 0; i < pcbdata.footprints.length; i++) {
     var mod = pcbdata.footprints[i];
     var outline = settings.renderDnpOutline && pcbdata.bom.skipped.includes(i);
-    if (!highlight || highlightedFootprints.includes(i)) {
+    if (!highlight) {
       drawFootprint(ctx, layer, scalefactor, mod, padcolor, outlinecolor, highlight, outline);
+    } else {
+      if(highlightedFootprints.includes(i)) {
+        if(darkenedFootprints.has(i)) {
+          drawFootprint(ctx, layer, scalefactor, mod, bothPadColor, bothOutlinecolor, highlight, outline);
+        } else {
+          drawFootprint(ctx, layer, scalefactor, mod, highlightedPadColor, highlightedOutlinecolor, highlight, outline);
+        }
+      } else {
+        if(darkenedFootprints.has(i)) {
+          console.log("darkened " + darkenedPadColor + "  plain " + padcolor);
+          drawFootprint(ctx, layer, scalefactor, mod, darkenedPadColor, darkenedOutlinecolor, highlight, outline);
+        } else {
+          drawFootprint(ctx, layer, scalefactor, mod, padcolor, outlinecolor, highlight, outline);
+        }
+      }
     }
   }
 }
@@ -443,7 +461,7 @@ function drawHighlightsOnLayer(canvasdict, clear = true) {
   if (clear) {
     clearCanvas(canvasdict.highlight);
   }
-  if (highlightedFootprints.length > 0) {
+  if (darkenedFootprints.size > 0 || highlightedFootprints.length > 0) {
     drawFootprints(canvasdict.highlight, canvasdict.layer,
       canvasdict.transform.s * canvasdict.transform.zoom, true);
   }

--- a/InteractiveHtmlBom/web/render.js
+++ b/InteractiveHtmlBom/web/render.js
@@ -364,7 +364,6 @@ function drawFootprints(canvas, layer, scalefactor, highlight) {
         }
       } else {
         if(darkenedFootprints.has(i)) {
-          console.log("darkened " + darkenedPadColor + "  plain " + padcolor);
           drawFootprint(ctx, layer, scalefactor, mod, darkenedPadColor, darkenedOutlinecolor, highlight, outline);
         } else {
           drawFootprint(ctx, layer, scalefactor, mod, padcolor, outlinecolor, highlight, outline);


### PR DESCRIPTION
When "Darken when checked" is enabled, footprints that match the
criterion chosen (i.e. sourced or placed) are highlighted in a separate
color.  The currently-highlighted footprint is also shown in a third
color if it has met the sourced/placed criterion.

Upstream issue #176.