### PR TITLE
Add symbolic link support

### DIFF
--- a/InteractiveHtmlBom/generate_interactive_bom.py
+++ b/InteractiveHtmlBom/generate_interactive_bom.py
@@ -17,7 +17,7 @@ def to_utf(s):
 if __name__ == "__main__":
     # Add ../ to the path
     # Works if this script is executed without installing the module
-    script_dir = os.path.dirname(os.path.abspath(__file__))
+    script_dir = os.path.dirname(os.path.abspath(os.path.realpath(__file__)))
     sys.path.insert(0, os.path.dirname(script_dir))
     os.environ['INTERACTIVE_HTML_BOM_CLI_MODE'] = 'True'
     import InteractiveHtmlBom


### PR DESCRIPTION
Close #212 

Not familiar with how to update the wiki, I can clone but don't see a direct way to merge/PR. Is there a direct way that you know of?

I was thinking to just update Usage.md to this:

> ### Standalone script
> 
> First determine which python version your KiCad installation supports. Go to `Help->About KiCad->Show version info` in main KiCad window and search for string `KICAD_SCRIPTING_PYTHON3`. If it says `ON` then you should use python3, otherwise python2.
> As of last update of this page only linux builds for recent distributions support python3, old linux builds, win and osx are still on python2. This plugin supports all platforms and python version combinations.
> 
> NOTE: A symlink can be created to the system bin folder (Example:  `~/.local/bin`) to remove the `path/to/InteractiveHtmlBom/` prefix. 
> 
> On Linux simply run this in terminal:
> 
> ```shell
> python2 path/to/InteractiveHtmlBom/generate_interactive_bom.py path/to/board.kicad_pcb
> ```
> or
> ```shell
> python3 path/to/InteractiveHtmlBom/generate_interactive_bom.py path/to/board.kicad_pcb
> ```
> 
> 
> On windows the trick is to use python that is bundled with KiCad so the command
> will look like this:
> 
> ```shell
> path/to/kicad/bin/python.exe .../generate_interactive_bom.py .../board.kicad_pcb
> ```