### PR TITLE
Grouping fix

### DIFF
--- a/InteractiveHtmlBom/core/ibom.py
+++ b/InteractiveHtmlBom/core/ibom.py
@@ -119,20 +119,20 @@ def generate_bom(pcb_footprints, config):
             continue
 
         # group part refs by value and footprint
-        norm_value = units.componentValue(f.val)
+        norm_value,unit = units.componentValue(f.val)
 
         extras = []
         if config.extra_fields:
             extras = [f.extra_fields.get(ef, '')
                       for ef in config.extra_fields]
 
-        group_key = (norm_value, tuple(extras), f.footprint, f.attr)
+        group_key = (norm_value,unit, tuple(extras), f.footprint, f.attr)
         valrefs = part_groups.setdefault(group_key, [f.val, []])
         valrefs[1].append((f.ref, i))
 
     # build bom table, sort refs
     bom_table = []
-    for (norm_value, extras, footprint, attr), valrefs in part_groups.items():
+    for (norm_value, unit, extras, footprint, attr), valrefs in part_groups.items():
         bom_row = (
             len(valrefs[1]), valrefs[0], footprint,
             natural_sort(valrefs[1]), extras)

--- a/InteractiveHtmlBom/core/ibom.py
+++ b/InteractiveHtmlBom/core/ibom.py
@@ -119,20 +119,20 @@ def generate_bom(pcb_footprints, config):
             continue
 
         # group part refs by value and footprint
-        norm_value,unit = units.componentValue(f.val)
+        norm_value, unit = units.componentValue(f.val)
 
         extras = []
         if config.extra_fields:
             extras = [f.extra_fields.get(ef, '')
                       for ef in config.extra_fields]
 
-        group_key = (norm_value,unit, tuple(extras), f.footprint, f.attr)
+        group_key = (norm_value, unit, tuple(extras), f.footprint, f.attr)
         valrefs = part_groups.setdefault(group_key, [f.val, []])
         valrefs[1].append((f.ref, i))
 
     # build bom table, sort refs
     bom_table = []
-    for (norm_value, unit, extras, footprint, attr), valrefs in part_groups.items():
+    for (_, _, extras, footprint, _), valrefs in part_groups.items():
         bom_row = (
             len(valrefs[1]), valrefs[0], footprint,
             natural_sort(valrefs[1]), extras)

--- a/InteractiveHtmlBom/core/units.py
+++ b/InteractiveHtmlBom/core/units.py
@@ -159,7 +159,7 @@ def componentValue(valString):
     if not len(result) == 2:  # result length is incorrect
         return valString, None  # return the same string back with `None` unit
 
-    return result #(val,unit)
+    return result  # (val,unit)
 
 
 # compare two values

--- a/InteractiveHtmlBom/core/units.py
+++ b/InteractiveHtmlBom/core/units.py
@@ -159,9 +159,7 @@ def componentValue(valString):
     if not len(result) == 2:  # result length is incorrect
         return valString
 
-    (val, unit) = result
-
-    return val
+    return result #(val,unit)
 
 
 # compare two values

--- a/InteractiveHtmlBom/core/units.py
+++ b/InteractiveHtmlBom/core/units.py
@@ -154,10 +154,10 @@ def componentValue(valString):
     result = compMatch(valString)
 
     if not result:
-        return valString  # return the same string back
+        return valString, None  # return the same string back with `None` unit
 
     if not len(result) == 2:  # result length is incorrect
-        return valString
+        return valString, None  # return the same string back with `None` unit
 
     return result #(val,unit)
 


### PR DESCRIPTION
This PR fixes an error in grouping of components by just their value and ignoring the unit.

That caused this:
![image_2021-02-16_02-45-03](https://user-images.githubusercontent.com/39218707/108008630-11275280-7001-11eb-8db8-88da09329300.png)

The fix is to include the unit as a key in `group_keys`, making components named 1uH, 1uF, 1uR, 1u unique.

`units.componentValue(valString)` isn't used anywhere else (AFAIK) so changing the return value should be fine.

Fallback `None`-units in `InteractiveHtmlBom/core/units.py:157,160` ensure proper execution for components without a unit as is the case with e.g. 2N7002-MOSFETs.

Keep in mind this is by no means fully tested!