### PR TITLE
Prevent default behvaior of Alt+[1-9]

### DIFF
--- a/InteractiveHtmlBom/web/ibom.js
+++ b/InteractiveHtmlBom/web/ibom.js
@@ -997,6 +997,7 @@ document.onkeydown = function(e) {
     }
     if (e.key >= '1' && e.key <= '9') {
       toggleBomCheckbox(currentHighlightedRowId, parseInt(e.key));
+      e.preventDefault();
     }
   }
 }


### PR DESCRIPTION
In Firefox Alt+[1-9] shortcuts are used to switch between tabs. It seems that a call to `preventDefault()` is missing.