### PR TITLE
Fixed extra_fields not loaded

### DIFF
--- a/InteractiveHtmlBom/dialog/settings_dialog.py
+++ b/InteractiveHtmlBom/dialog/settings_dialog.py
@@ -233,7 +233,8 @@ class ExtraFieldsPanel(dialog_base.ExtraFieldsPanelBase):
 
     def OnSize(self, event):
         # Trick the listCheckBox best size calculations
-        tmp = self.extraFieldsList.GetStrings()
+        items, checked = self.extraFieldsList.GetStrings(), self.extraFieldsList.GetCheckedStrings()
         self.extraFieldsList.SetItems([])
         self.Layout()
-        self.extraFieldsList.SetItems(tmp)
+        self.extraFieldsList.SetItems(items)
+        self.extraFieldsList.SetCheckedStrings(checked)

--- a/InteractiveHtmlBom/dialog/settings_dialog.py
+++ b/InteractiveHtmlBom/dialog/settings_dialog.py
@@ -233,8 +233,9 @@ class ExtraFieldsPanel(dialog_base.ExtraFieldsPanelBase):
 
     def OnSize(self, event):
         # Trick the listCheckBox best size calculations
-        items, checked = self.extraFieldsList.GetStrings(), self.extraFieldsList.GetCheckedStrings()
+        items = self.extraFieldsList.GetStrings()
+        checked_items = self.extraFieldsList.GetCheckedStrings()
         self.extraFieldsList.SetItems([])
         self.Layout()
         self.extraFieldsList.SetItems(items)
-        self.extraFieldsList.SetCheckedStrings(checked)
+        self.extraFieldsList.SetCheckedStrings(checked_items)


### PR DESCRIPTION
In 84c4db8, a regression was introduced. While clearing and restoring the extraFieldsList, the checked items are not restored.