### PR TITLE
fix #153. Chinese working fine now.

### DIFF
--- a/InteractiveHtmlBom/Run.bat
+++ b/InteractiveHtmlBom/Run.bat
@@ -5,7 +5,16 @@ set FilePath=%~dp0
 ::delete --show-dialog after frist start up and setting
 set option=--show-dialog
 
-call %FilePath%\i18n\language_en.bat
+::detect current language of user.
+FOR /F "tokens=3" %%a IN ('reg query "HKCU\Control Panel\Desktop" /v PreferredUILanguages ^| find "PreferredUILanguages"') DO set language=%%a
+set language=%language:~,2%
+if %language%==zh (
+	call %FilePath%\i18n\language_zh.bat
+) else (
+	call %FilePath%\i18n\language_en.bat
+)
+
+cls
 
 echo -------------------------------------------------------------------------------------------------------------------
 echo -------------------------------------------------------------------------------------------------------------------

--- a/InteractiveHtmlBom/i18n/.gitattributes
+++ b/InteractiveHtmlBom/i18n/.gitattributes
@@ -1,1 +1,1 @@
-language_zh.bat eol=crlf
+*.bat eol=crlf

--- a/InteractiveHtmlBom/i18n/.gitattributes
+++ b/InteractiveHtmlBom/i18n/.gitattributes
@@ -1,0 +1,1 @@
+language_zh.bat eol=crlf

--- a/InteractiveHtmlBom/i18n/language_zh.bat
+++ b/InteractiveHtmlBom/i18n/language_zh.bat
@@ -1,0 +1,17 @@
+::This file needs to be in 'UTF-8 encoding' AND 'Windows CR LF' to work.
+
+::set active code page as UTF-8/65001
+set PYTHONIOENCODING=utf-8
+chcp 65001
+::start up echo
+set i18n_gitAddr=                                https://github.com/openscopeproject/InteractiveHtmlBom
+set i18n_batScar=                                           Bat 文件： Scarrrr0725/XiaoMingXD
+set i18n_thx4using=                                           感谢使用 Generate Interactive Bom
+
+::convert
+set i18n_draghere=请将您的EDA PCB源文件拖移至此 :
+set i18n_converting=导出中 . . . . . ."
+
+::converted
+set i18n_again=请问是否转换其他文件 ？ 
+set i18n_converted=                                    您的EDA源文件已成功导出 Bom ！


### PR DESCRIPTION
The Chinese i18n language file needs to be in UTF-8 encoding to show the correct character on Windows with the 'chcp 65001'.
I don't understand why here has 'chcp 65001'. So I decided to keep it and move it into the i18n language file.

Change LF to CRLF fix the "'XX' is not recognized as an internal or external command." problem.
The Windows cmd can't correctly recognize the LF as the ending of a line.

Even most Chinese users can understand those English sentences in the batch file, it's always good to have a Chinese translation. 