### PR TITLE
fix: the cmd flashes back when the System Registry does not have a PreferredUILanguages project

### DIFF
--- a/InteractiveHtmlBom/Run.bat
+++ b/InteractiveHtmlBom/Run.bat
@@ -6,12 +6,30 @@ set FilePath=%~dp0
 set option=--show-dialog
 
 ::detect current language of user.
+reg query "HKCU\Control Panel\Desktop" /v PreferredUILanguages>nul 2>nul&&goto _dosearch1_||goto _dosearch2_
+
+:_dosearch1_
+FOR /F "tokens=3" %%a IN (
+	'reg query "HKCU\Control Panel\Desktop" /v PreferredUILanguages ^| find "PreferredUILanguages"'
+) DO (
+	set language=%%a
+)
+set language=%language:~,2%
+goto _setlanguage_
+
+:_dosearch2_
 FOR /F "tokens=3" %%a IN (
 	'reg query "HKLM\SYSTEM\ControlSet001\Control\Nls\Language" /v InstallLanguage ^| find "InstallLanguage"'
 ) DO (
 	set language=%%a
 )
 if %language%==0804 (
+	set language=zh
+)
+goto _setlanguage_
+
+:_setlanguage_
+if %language%==zh (
 	call %FilePath%\i18n\language_zh.bat
 ) else (
 	call %FilePath%\i18n\language_en.bat
@@ -31,7 +49,7 @@ echo ---------------------------------------------------------------------------
 
 set pyFilePath=%FilePath%generate_interactive_bom.py
 
-:convert
+:_convert_
 if not defined pathofEDASourceFile (
 	set /p pathofEDASourceFile=%i18n_draghere%
 )
@@ -52,4 +70,4 @@ echo ---------------------------------------------------------------------------
 
 CHOICE /C YN /N /M "%i18n_again% [ Y/N ]"
 	if errorlevel 2 exit
-	if errorlevel 1 goto convert
+	if errorlevel 1 goto _convert_

--- a/InteractiveHtmlBom/Run.bat
+++ b/InteractiveHtmlBom/Run.bat
@@ -6,9 +6,12 @@ set FilePath=%~dp0
 set option=--show-dialog
 
 ::detect current language of user.
-FOR /F "tokens=3" %%a IN ('reg query "HKCU\Control Panel\Desktop" /v PreferredUILanguages ^| find "PreferredUILanguages"') DO set language=%%a
-set language=%language:~,2%
-if %language%==zh (
+FOR /F "tokens=3" %%a IN (
+	'reg query "HKLM\SYSTEM\ControlSet001\Control\Nls\Language" /v InstallLanguage ^| find "InstallLanguage"'
+) DO (
+	set language=%%a
+)
+if %language%==0804 (
 	call %FilePath%\i18n\language_zh.bat
 ) else (
 	call %FilePath%\i18n\language_en.bat

--- a/InteractiveHtmlBom/i18n/language_en.bat
+++ b/InteractiveHtmlBom/i18n/language_en.bat
@@ -1,7 +1,7 @@
 ::start up echo
 set i18n_gitAddr=                                 https://github.com/openscopeproject/InteractiveHtmlBom
 set i18n_batScar=                                                Bat file by Scarrrr0725
-set i18n_thx4using=                                       Thankyou For Using Generate Interactive Bom
+set i18n_thx4using=                                      Thank You For Using Generate Interactive Bom
 
 ::convert
 set i18n_draghere=Please Drag the EasyEDA PCB source file here :

--- a/InteractiveHtmlBom/i18n/language_zh.bat
+++ b/InteractiveHtmlBom/i18n/language_zh.bat
@@ -9,9 +9,9 @@ set i18n_batScar=                                           Bat 文件： Scarrr
 set i18n_thx4using=                                           感谢使用 Generate Interactive Bom
 
 ::convert
-set i18n_draghere=请将您的EDA PCB源文件拖移至此 :
+set i18n_draghere=请将您的 EDA PCB 源文件拖移至此：
 set i18n_converting=导出中 . . . . . ."
 
 ::converted
-set i18n_again=请问是否转换其他文件 ？ 
-set i18n_converted=                                    您的EDA源文件已成功导出 Bom ！
+set i18n_again=请问是否转换其他文件？
+set i18n_converted=                                   您的 EDA 源文件已成功导出 Bom！


### PR DESCRIPTION
When the System Registry does not have a PreferredUILanguages project, the execution of cmd will flash back and be 100% re-emerged.
In a newly installed Windows 10 system, there will be no PreferredUILanguages project in the registry if the user has not viewed or edited the system UI settings.