### PR TITLE
Fix dimension parsing problem with KiCad 6.0.4

### DIFF
--- a/InteractiveHtmlBom/ecad/kicad.py
+++ b/InteractiveHtmlBom/ecad/kicad.py
@@ -321,7 +321,7 @@ class PcbnewParser(EcadParser):
             s = self.parse_shape(d)
         elif d.GetClass() in ["PTEXT", "MTEXT", "FP_TEXT", "PCB_TEXT"]:
             s = self.parse_text(d)
-        elif d.GetClass().startswith("PCB_DIM"):
+        elif d.GetClass().startswith("PCB_DIM") and hasattr(pcbnew, "VECTOR_SHAPEPTR"):
             result.append(self.parse_dimension(d))
             s = self.parse_text(d.Text())
         else:


### PR DESCRIPTION
The GetShapes member in KiCad 6.0.4 is declared as:

```python
    def GetShapes(self) -> "std::vector< std::shared_ptr< SHAPE >,std::allocator< std::shared_ptr< SHAPE > > > const &":
        r"""GetShapes(PCB_DIMENSION_BASE self) -> std::vector< std::shared_ptr< SHAPE >,std::allocator< std::shared_ptr< SHAPE > > > const &"""
        return _pcbnew.PCB_DIMENSION_BASE_GetShapes(self)
```

So we can't use it from Python. Trying to use it generates `TypeError`. So this patch skips the dimensions when we get the exception.