### PR TITLE
kicad: seed component extra_fields with properties

### DIFF
--- a/InteractiveHtmlBom/ecad/kicad.py
+++ b/InteractiveHtmlBom/ecad/kicad.py
@@ -648,12 +648,18 @@ class PcbnewParser(EcadParser):
             pcbnew.B_Cu: 'B',
         }.get(footprint.GetLayer())
 
+        if hasattr(footprint, "GetProperties"):
+            merged_extra_fields = footprint.GetProperties()
+            merged_extra_fields.update(extra_fields)
+        else:
+            merged_extra_fields = extra_fields
+
         return Component(footprint.GetReference(),
                          footprint.GetValue(),
                          footprint_name,
                          layer,
                          attr,
-                         extra_fields)
+                         merged_extra_fields)
 
     def parse(self):
         from ..errors import ParsingException
@@ -668,7 +674,7 @@ class PcbnewParser(EcadParser):
                              self.config.dnp_field)
 
         if not self.config.extra_data_file and need_extra_fields:
-            self.logger.warn('Ignoring extra fields related config parameters '
+            self.logger.warn('May ignore extra fields related config parameters '
                              'since no netlist/xml file was specified.')
             need_extra_fields = False
 
@@ -678,7 +684,7 @@ class PcbnewParser(EcadParser):
             extra_field_data = self.parse_extra_data(
                 self.config.extra_data_file, self.config.normalize_field_case)
 
-        if extra_field_data is None and need_extra_fields:
+        if extra_field_data is None and self.config.extra_data_file:
             raise ParsingException(
                 'Failed parsing %s' % self.config.extra_data_file)
 


### PR DESCRIPTION
Thanks for this project, I have been enjoying using it!

#### Background

Using a KiCad 6.0 PCB and the command line tool I tried to include part numbers in the BoM:

```bash
python3 ./generate_interactive_bom.py ~/git/poe-addon/poe-addon.kicad_pcb \
    --show-fields 'Value,DigiKey Part Number' \
    --group-fields 'DigiKey Part Number'
```

I got this warning:

https://github.com/openscopeproject/InteractiveHtmlBom/blob/f395b8ac9e46507e46e36389139068642337d68b/InteractiveHtmlBom/ecad/kicad.py#L670-L673

I noticed that the information I wanted was in the properties of the footprint of the `kicad_pcb` file, and could be extracted without additional files.

#### Changes Made

The `pcbnew.FOOTPRINT` object has a `GetProperties` method [[1]].

This contains various component properites, for example:

```python
{
    'DigiKey Part Number': '1276-1921-1-ND',
    'Sheetfile': 'poe-addon.kicad_sch',
    'Sheetname': '',
    'Tolerance': '10%',
    'Voltage': '50V'
}
```

The changes made merge these properties with extra data files, prioritizing the `extra_fields`.  This makes it easier for users because they do not need to generate extra files in order to extract these properties.

These changes should be backwards compatible:
1. Data files are prioritized if there are duplicate keys.
2. The merge is not performed if the `GetProperties` method does not exist.

[1]: https://docs.kicad.org/doxygen-python/classpcbnew_1_1FOOTPRINT.html#a1b4c9b5be1c942cc77339b4e8cddf614
