### PR TITLE
Fix clash of 2f38736 with 39fc0c4

### DIFF
--- a/InteractiveHtmlBom/web/ibom.js
+++ b/InteractiveHtmlBom/web/ibom.js
@@ -663,7 +663,7 @@ function populateBomBody(placeholderColumn = null, placeHolderElements = null) {
           var output = new Array();
           for (let item of valueSet) {
             const visible = highlightFilter(item);
-            if (item.match(urlRegex)) {
+            if (typeof item === 'string' && item.match(urlRegex)) {
               output.push(`<a href="${item}" target="_blank">${visible}</a>`);
             } else {
               output.push(visible);
@@ -1149,7 +1149,7 @@ document.onkeydown = function (e) {
         boardRotationElement.value = settings.boardRotation
         setBoardRotation(settings.boardRotation);
       }
-      break;      
+      break;
     default:
       break;
   }


### PR DESCRIPTION
I noticed that https://github.com/openscopeproject/InteractiveHtmlBom/commit/39fc0c466cf1bd98464efae56c9713aaddbeb5a3 assumes that the values are strings. However, https://github.com/openscopeproject/InteractiveHtmlBom/commit/2f38736d8506f45c6a0945eccea1497e02fef1af makes this assumption invalid. As a result, if there are numeric columns, the BOM is not displayed.

As numbers cannot be URLs, I suggest URL matching only on a string.