### PR TITLE
Improve .BRD library package lookup (fix #351)

### DIFF
--- a/InteractiveHtmlBom/ecad/fusion_eagle.py
+++ b/InteractiveHtmlBom/ecad/fusion_eagle.py
@@ -111,9 +111,9 @@ class FusionEagleParser(EcadParser):
                                        if d in string.digits + '.'))
 
         def __str__(self):
-            return f"Mirrored: {self.mirrored}, " \
-                   f"Spin: {self.spin}, " \
-                   f"Angle: {self.angle}"
+            return "Mirrored: {0}, Spin: {1}, Angle: {2}".format(self.mirrored,
+                                                                 self.spin,
+                                                                 self.angle)
 
     def _rectangle_vertices(self, el):
         # Note: Eagle specifies a rectangle using opposing corners
@@ -790,18 +790,20 @@ class FusionEagleParser(EcadParser):
                      if pac.attrib['name'] == el.attrib['package']]
                 packages.extend(p)
             if not packages:
-                self.logger.error(f"Package {el.attrib['package']} in library "
-                                  f"{el.attrib['library']} not found in "
-                                  f"source file {brdfile.name} for "
-                                  f"element {el.attrib['name']}")
+                self.logger.error("Package {0} in library {1} not found in "
+                                  "source file {2} for element {3}"
+                                  .format(el.attrib['package'],
+                                          el.attrib['library'],
+                                          brdfile.name,
+                                          el.attrib['name']))
                 return None, None
             else:
                 package = packages[0]
                 if len(packages) > 1:
-                    self.logger.warn(f"Multiple packages found for package "
-                                     f"{el.attrib['package']} in "
-                                     f"library {el.attrib['library']}, "
-                                     f"using first instance found")
+                    self.logger.warn("Multiple packages found for package {0}"
+                                     " in library {1}, using first instance "
+                                     "found".format(el.attrib['package'],
+                                                    el.attrib['library']))
 
             elx = float(el.attrib['x'])
             ely = float(el.attrib['y'])
@@ -850,7 +852,7 @@ class FusionEagleParser(EcadParser):
                    a.get('current') == 'yes']
         variant = None if not variant else variant[0]
         if variant:
-            title = f"{title}, Variant: {variant}"
+            title = "{0}, Variant: {1}".format(title, variant)
 
         date = datetime.fromtimestamp(
             os.path.getmtime(self.file_name)).strftime('%Y-%m-%d %H:%M:%S')

--- a/InteractiveHtmlBom/ecad/fusion_eagle.py
+++ b/InteractiveHtmlBom/ecad/fusion_eagle.py
@@ -782,11 +782,26 @@ class FusionEagleParser(EcadParser):
                              extra_fields=extra_fields)
 
             # For component, get footprint data
-            library = [lib for lib in board.find('libraries').findall('library')
-                       if lib.attrib['name'] == el.attrib['library']][0]
-            package = \
-                [pac for pac in library.find('packages').findall('package')
-                 if pac.attrib['name'] == el.attrib['package']][0]
+            libs = [lib for lib in board.find('libraries').findall('library')
+                       if lib.attrib['name'] == el.attrib['library']]
+            packages = []
+            for lib in libs:
+                p = [pac for pac in lib.find('packages').findall('package')
+                     if pac.attrib['name'] == el.attrib['package']]
+                packages.extend(p)
+            if not packages:
+                self.logger.error(f"Package {el.attrib['package']} in library "
+                                  f"{el.attrib['library']} not found in "
+                                  f"source file {brdfile.name} for "
+                                  f"element {el.attrib['name']}")
+                return None, None
+            else:
+                package = packages[0]
+                if len(packages) > 1:
+                    self.logger.warn(f"Multiple packages found for package "
+                                     f"{el.attrib['package']} in "
+                                     f"library {el.attrib['library']}, "
+                                     f"using first instance found")
 
             elx = float(el.attrib['x'])
             ely = float(el.attrib['y'])


### PR DESCRIPTION
Handle the case where there are multiple identically-named libraries in .BRD file. 
 Also add sanity checking for package not found (error) or multiple ambiguous packages found (warning)