### PR TITLE
respect KiCad 7's new DNP attribute and implement options to show DNP components in BOM table

### DIFF
--- a/DATAFORMAT.md
+++ b/DATAFORMAT.md
@@ -101,8 +101,10 @@ pcbdata = {
     "both": [bomrow1, bomrow2, ...],
     "F":  [bomrow1, bomrow2, ...],
     "B":  [bomrow1, bomrow2, ...],
-    // numeric IDs of DNP components that are not in BOM
+    // numeric IDs of virtual or exclude_from_bom components
     "skipped": [id1, id2, ...]
+    // numeric IDs of blacklisted components (DNPs)
+    "dnp": [id1, id2, ...]
     // Fields map is keyed on component ID with values being field data.
     // It's order corresponds to order of fields data in config struct.
     "fields" {

--- a/InteractiveHtmlBom/core/config.py
+++ b/InteractiveHtmlBom/core/config.py
@@ -38,9 +38,9 @@ class Config:
         'dark_mode', 'show_pads', 'show_fabrication', 'show_silkscreen',
         'highlight_pin1', 'redraw_on_drag', 'board_rotation', 'checkboxes',
         'bom_view', 'layer_view', 'offset_back_rotation',
-        'kicad_text_formatting'
+        'kicad_text_formatting', 'show_dnp', 'count_dnp',
     ]
-    default_show_group_fields = ["Value", "Footprint"]
+    default_show_group_fields = ["Value", "Footprint", "dnp"]
 
     # Defaults
 
@@ -58,6 +58,8 @@ class Config:
     layer_view = layer_view_choices[1]
     compression = True
     open_browser = True
+    show_dnp = False
+    count_dnp = False
 
     # General section
     bom_dest_dir = 'bom/'  # This is relative to pcb file directory
@@ -124,6 +126,8 @@ class Config:
         self.layer_view = f.Read('layer_view', self.layer_view)
         self.compression = f.ReadBool('compression', self.compression)
         self.open_browser = f.ReadBool('open_browser', self.open_browser)
+        self.show_dnp = f.ReadBool('show_dnp', self.show_dnp)
+        self.count_dnp = f.ReadBool('count_dnp', self.count_dnp)
 
         f.SetPath('/general')
         self.bom_dest_dir = f.Read('bom_dest_dir', self.bom_dest_dir)
@@ -177,6 +181,8 @@ class Config:
         f.Write('layer_view', self.layer_view)
         f.WriteBool('compression', self.compression)
         f.WriteBool('open_browser', self.open_browser)
+        f.WriteBool('show_dnp', self.show_dnp)
+        f.WriteBool('count_dnp', self.count_dnp)
 
         f.SetPath('/general')
         bom_dest_dir = self.bom_dest_dir
@@ -224,6 +230,8 @@ class Config:
             dlg.html.layerDefaultView.Selection]
         self.compression = dlg.html.compressionCheckbox.IsChecked()
         self.open_browser = dlg.html.openBrowserCheckbox.IsChecked()
+        # TODO: self.show_dnp
+        # TODO: self.count_dnp
 
         # General
         self.bom_dest_dir = dlg.general.bomDirPicker.Path
@@ -271,6 +279,8 @@ class Config:
             self.layer_view)
         dlg.html.compressionCheckbox.Value = self.compression
         dlg.html.openBrowserCheckbox.Value = self.open_browser
+        # TODO: show_dnp
+        # TODO: count_dnp
 
         # General
         import os.path
@@ -331,6 +341,9 @@ class Config:
         parser.add_argument('--hide-silkscreen',
                             help='Hide silkscreen by default.',
                             action='store_true')
+        parser.add_argument('--count-dnp-components', action='store_true',
+                            help='Count components with DNP attribute set '
+                                 'by default.')
         parser.add_argument('--highlight-pin1',
                             help='Highlight pin1 by default.',
                             action='store_true')
@@ -344,6 +357,10 @@ class Config:
         parser.add_argument('--offset-back-rotation',
                             help='Offset the back of the pcb by 180 degrees',
                             action='store_true')
+        parser.add_argument('--show-dnp', action='store_true',
+                            help='Show DNP components in the bom table.')
+        parser.add_argument('--count-dnp', action='store_true',
+                            help='Count DNP components (if shown).')
         parser.add_argument('--checkboxes',
                             default=cls.checkboxes,
                             help='Comma separated list of checkbox columns.')
@@ -435,6 +452,8 @@ class Config:
         self.layer_view = args.layer_view
         self.compression = not args.no_compression
         self.open_browser = not args.no_browser
+        self.show_dnp = args.show_dnp
+        self.count_dnp = args.count_dnp
 
         # General
         self.bom_dest_dir = args.dest_dir

--- a/InteractiveHtmlBom/ecad/kicad.py
+++ b/InteractiveHtmlBom/ecad/kicad.py
@@ -25,7 +25,7 @@ class PcbnewParser(EcadParser):
         self.font_parser = FontParser()
 
     def get_extra_field_data(self, file_name):
-        if os.path.abspath(file_name) == os.path.abspath(self.file_name):
+        if os.path.samefile(file_name, self.file_name):
             return self.parse_extra_data_from_pcb()
         if os.path.splitext(file_name)[1] == '.kicad_pcb':
             return None
@@ -42,7 +42,10 @@ class PcbnewParser(EcadParser):
 
             for k, v in props.items():
                 field_set.add(k)
-                ref_fields[k] = v
+                if k == 'dnp':
+                    ref_fields[k] = '' if v is None else 'DNP'
+                else:
+                    ref_fields[k] = v
 
         return list(field_set), comp_dict
 

--- a/InteractiveHtmlBom/ecad/kicad_extra/xmlparser.py
+++ b/InteractiveHtmlBom/ecad/kicad_extra/xmlparser.py
@@ -19,6 +19,7 @@ class XmlParser(ParserBase):
         comp_dict = {}
         for c in components:
             ref_fields = comp_dict.setdefault(c.attributes['ref'].value, {})
+            dnp = c.getElementsByTagName('dnp')
             datasheet = c.getElementsByTagName('datasheet')
             if datasheet:
                 datasheet = self.get_text(datasheet[0].childNodes)
@@ -30,9 +31,14 @@ class XmlParser(ParserBase):
                 field_set.add('Description')
                 attr = libsource[0].attributes['description']
                 ref_fields['Description'] = attr.value
+            for f in c.getElementsByTagName('property'):
+                if f.attributes['name'].value == 'dnp':
+                    dnp = 'DNP'
             for f in c.getElementsByTagName('field'):
                 name = f.attributes['name'].value
                 field_set.add(name)
                 ref_fields[name] = self.get_text(f.childNodes)
+            if (dnp not in [None, []]):
+                ref_fields['dnp'] = dnp
 
         return list(field_set), comp_dict

--- a/InteractiveHtmlBom/web/ibom.html
+++ b/InteractiveHtmlBom/web/ibom.html
@@ -120,6 +120,17 @@
             Offset back rotation
           </label>
           <label class="menu-label">
+            <div style="margin-bottom: 5px;">Bom table</div>
+            <label style="width: calc(50% - 18px);">
+              <input id="showDNPCheckbox" type="checkbox" onchange="setShowDNP(this.checked)">
+              <span title="If checked, DNP devices are shown in the bom table">Show DNP</span>
+            </label>
+            <label style="width: calc(50%); float: right">
+              <input id="countDNPCheckbox" type="checkbox" onchange="setCountDNP(this.checked)">
+              <span title="If checked, DNP devices are counted in the bom table and statistics">Count DNP</span>
+            </label>
+          </label>
+          <label class="menu-label">
             <div style="margin-left: 5px">Bom checkboxes</div>
             <input id="bomCheckboxes" class="menu-textbox" type=text
                    oninput="setBomCheckboxes(this.value)">

--- a/InteractiveHtmlBom/web/render.js
+++ b/InteractiveHtmlBom/web/render.js
@@ -378,7 +378,7 @@ function drawFootprints(canvas, layer, scalefactor, highlight) {
 
   for (var i = 0; i < pcbdata.footprints.length; i++) {
     var mod = pcbdata.footprints[i];
-    var outline = settings.renderDnpOutline && pcbdata.bom.skipped.includes(i);
+    var outline = settings.renderDnpOutline && (pcbdata.bom.skipped.includes(i) || pcbdata.bom.dnp.includes(i));
     var h = highlightedFootprints.includes(i);
     var d = markedFootprints.has(i);
     if (highlight) {

--- a/InteractiveHtmlBom/web/util.js
+++ b/InteractiveHtmlBom/web/util.js
@@ -430,6 +430,10 @@ function overwriteSettings(newSettings) {
   document.getElementById("zonesCheckbox").checked = settings.renderZones;
   dnpOutline(settings.renderDnpOutline);
   document.getElementById("dnpOutlineCheckbox").checked = settings.renderDnpOutline;
+  setCountDNP(settings.countDNP);
+  document.getElementById("countDNPCheckbox").checked = settings.countDNP;
+  setShowDNP(settings.showDNP);
+  document.getElementById("showDNPCheckbox").checked = settings.showDNP;
   setRedrawOnDrag(settings.redrawOnDrag);
   document.getElementById("dragCheckbox").checked = settings.redrawOnDrag;
   setDarkMode(settings.darkMode);
@@ -545,6 +549,8 @@ function initDefaults() {
     zonesVisible(false);
   }
   initBooleanSetting("dnpOutline", false, "dnpOutlineCheckbox", dnpOutline);
+  initBooleanSetting("showDNP", false, "showDNPCheckbox", setShowDNP);
+  initBooleanSetting("countDNP", false, "countDNPCheckbox", setCountDNP);
   initBooleanSetting("redrawOnDrag", config.redraw_on_drag, "dragCheckbox", setRedrawOnDrag);
   initBooleanSetting("darkmode", config.dark_mode, "darkmodeCheckbox", setDarkMode);
   initBooleanSetting("highlightpin1", config.highlight_pin1, "highlightpin1Checkbox", setHighlightPin1);

--- a/InteractiveHtmlBom/web/util.js
+++ b/InteractiveHtmlBom/web/util.js
@@ -549,8 +549,8 @@ function initDefaults() {
     zonesVisible(false);
   }
   initBooleanSetting("dnpOutline", false, "dnpOutlineCheckbox", dnpOutline);
-  initBooleanSetting("showDNP", false, "showDNPCheckbox", setShowDNP);
-  initBooleanSetting("countDNP", false, "countDNPCheckbox", setCountDNP);
+  initBooleanSetting("showDNP", config.show_dnp, "showDNPCheckbox", setShowDNP);
+  initBooleanSetting("countDNP", config.count_dnp, "countDNPCheckbox", setCountDNP);
   initBooleanSetting("redrawOnDrag", config.redraw_on_drag, "dragCheckbox", setRedrawOnDrag);
   initBooleanSetting("darkmode", config.dark_mode, "darkmodeCheckbox", setDarkMode);
   initBooleanSetting("highlightpin1", config.highlight_pin1, "highlightpin1Checkbox", setHighlightPin1);


### PR DESCRIPTION
This MR is motivated by two reasons:
1. KiCad 7 has a `dnp` flag which is not yet interpreted
2. My PCB manufacturer requires BOM tables that include the DNP components (with a summary count of 0)

I've worked my way through this wonderful piece of code (1000 thanks for this, @qu1ck) and thought I'd implement something to eventually being pulled into the main branch (or refactored as you like).

### Some Screenshots:

* This shows the new options in the BOM<br>
![new_options](https://user-images.githubusercontent.com/6793194/221947070-e9543399-c461-4476-8ed0-997aeee67fb0.png)

* DNP parts shown and not counted (this is how my PCB manufacturer wants it)<br>
![DNP_shown_uncounted](https://user-images.githubusercontent.com/6793194/221947562-f1d125be-8000-4608-b5cb-058ba3ab392c.png)

* DNP parts shown and counted<br>
![DNP_shown_and_counted](https://user-images.githubusercontent.com/6793194/221947752-29c8c088-9897-4846-bf10-9ce53bd0f77f.png)

* Normal statistics<br>
![statistics_when_unshown_or_uncounted](https://user-images.githubusercontent.com/6793194/221947868-6216e379-52e1-4ed2-a68c-9c5a33a417f6.png)

* In case DNPs are shown and counted, statistics are modified<br>
![statistics_when_shown_and_counted](https://user-images.githubusercontent.com/6793194/221948021-1edb7f6c-d47e-416a-a494-2a2c709c73d5.png)

### Some Notes:
* I have never programmed JS before, so there might be more elegant ways to implement my changes, but I tried to do my best.
* I'd really appreciate if the functionality of integrating DNP parts into the iBom would become part of this project
* @qu1ck, I guess you know how you can contact me about this on Zulip.