### PR TITLE
Exception when including a bool field

### DIFF
--- a/InteractiveHtmlBom/core/ibom.py
+++ b/InteractiveHtmlBom/core/ibom.py
@@ -163,6 +163,9 @@ def generate_bom(pcb_footprints, config):
             continue
         all_num = True
         for f in index_to_fields.values():
+            if not hasattr(f[i], 'isdigit'):
+                all_num = False
+                break
             if not f[i].isdigit() and len(f[i].strip()) > 0:
                 all_num = False
                 break


### PR DESCRIPTION
With Kicad 7.0, attempted to view the 'kicad_dnp' field and it generated an exception, attempting to call is_digit() on something without the method.
![kicad_dnp_error](https://github.com/openscopeproject/InteractiveHtmlBom/assets/1799255/2afc6404-6154-4f57-84cb-9b58091890c9)
This patch simply checks if the attribute is present and, if not, takes for granted that we have things other than digit strings in our set. 