### PR TITLE
Fix issue of config being shared

### DIFF
--- a/InteractiveHtmlBom/core/config.py
+++ b/InteractiveHtmlBom/core/config.py
@@ -480,4 +480,9 @@ class Config:
         import json
         d = {f: getattr(self, f) for f in self.html_config_fields}
         d["fields"] = self.show_fields
+
+        # Generate a unique id for the config
+        from secrets import token_hex
+        d["id"] = token_hex(3)
+
         return json.dumps(d)

--- a/InteractiveHtmlBom/web/util.js
+++ b/InteractiveHtmlBom/web/util.js
@@ -1,7 +1,7 @@
 /* Utility functions */
 
 var storagePrefix = 'KiCad_HTML_BOM__' + pcbdata.metadata.title + '__' +
-  pcbdata.metadata.revision + '__#';
+  pcbdata.metadata.revision + config.id + '__#';
 var storage;
 
 function initStorage(key) {


### PR DESCRIPTION
The storagePrefix in HTML is not unique, multiple file with the same pcbdata in the same directory will share the config.
A simple solution is to add a unique id when generating the HTML.

Note: secrets is a standard library in python and does not require additional installation.