### PR TITLE
Added columns Position X, Position Y, Rotation to fields

### DIFF
--- a/InteractiveHtmlBom/dialog/settings_dialog.py
+++ b/InteractiveHtmlBom/dialog/settings_dialog.py
@@ -340,7 +340,7 @@ class FieldsPanel(dialog_base.FieldsPanelBase):
 
         if self.extra_field_data is not None:
             field_list = list(self.extra_field_data.fields)
-            self._setFieldsList(["Value", "Footprint"] + field_list)
+            self._setFieldsList(["Value", "Footprint", "Position X", "Position Y", "Rotation"] + field_list)
             self.SetCheckedFields()
             field_list.append(self.NONE_STRING)
             self.boardVariantFieldBox.SetItems(field_list)

--- a/InteractiveHtmlBom/web/ibom.js
+++ b/InteractiveHtmlBom/web/ibom.js
@@ -586,6 +586,15 @@ function populateBomHeader(placeHolderColumn = null, placeHolderElements = null)
         tr.appendChild(createColumnHeader("Quantity", "quantity", (a, b) => {
           return a.length - b.length;
         }));
+      } else if (column === "Position X") {
+        tr.appendChild(createColumnHeader(
+          "Position X", "position_x", ""));
+      } else if (column === "Position Y") {
+        tr.appendChild(createColumnHeader(
+          "Position Y", "position_y", ""));
+      } else if (column === "Rotation") {
+        tr.appendChild(createColumnHeader(
+          "Rotation", "rotation", ""));
       } else {
         // Other fields
         var i = config.fields.indexOf(column);
@@ -712,6 +721,24 @@ function populateBomBody(placeholderColumn = null, placeHolderElements = null) {
           // Quantity
           td = document.createElement("TD");
           td.textContent = references.length;
+          tr.appendChild(td);
+        } else if (column === "Position X" && settings.bommode != "grouped") {
+          td = document.createElement("TD");
+          var position_refname = references.map(r => r[0]).join(", ");
+          var position_value = pcbdata.footprints.find((element) => element.ref == position_refname);
+          td.textContent = position_value.bbox.pos[0];
+          tr.appendChild(td);
+        } else if (column === "Position Y" && settings.bommode != "grouped") {
+          td = document.createElement("TD");
+          var position_refname = references.map(r => r[0]).join(", ");
+          var position_value = pcbdata.footprints.find((element) => element.ref == position_refname);
+          td.textContent = position_value.bbox.pos[1];
+          tr.appendChild(td);
+        } else if (column === "Rotation" && settings.bommode != "grouped") {
+          td = document.createElement("TD");
+          var position_refname = references.map(r => r[0]).join(", ");
+          var position_value = pcbdata.footprints.find((element) => element.ref == position_refname);
+          td.textContent = position_value.bbox.angle;
           tr.appendChild(td);
         } else {
           // All the other fields


### PR DESCRIPTION
I added support to export position (X, Y) and rotation. This way, you can create a combined BOM with placement information.

We needed this because we need the positioning file with added custom fields, e.g. the article number from ERP. I think this function can be really helpful. I would be delighted if you can merge this addition into the master branch.

Best regards,
Alex

![grafik](https://github.com/user-attachments/assets/92e47c9a-9ae3-4214-9253-fa6ae9fa9bc5)
![grafik](https://github.com/user-attachments/assets/16fe74a8-6b1f-43f2-80ae-82216eb0e7bd)

