### PR TITLE
Add support of rectangle pad hole

### DIFF
--- a/DATAFORMAT.md
+++ b/DATAFORMAT.md
@@ -324,7 +324,7 @@ Footprints are a collection of pads, drawings and some metadata.
       // "smd" otherwise.
       "type": type,
       // Present only if type is "th".
-      // One of "circle", "oblong".
+      // One of "circle", "oblong" or "rect".
       "drillshape": drillshape,
       // Present only if type is "th". In case of circle shape x is diameter, y is ignored.
       "drillsize": [x, y],

--- a/InteractiveHtmlBom/ecad/schema/genericjsonpcbdata_v1.schema
+++ b/InteractiveHtmlBom/ecad/schema/genericjsonpcbdata_v1.schema
@@ -462,7 +462,8 @@
             "type": "string",
             "enum": [
                 "circle",
-                "oblong"
+                "oblong",
+                "rect"
             ],
             "title": "Drillshape"
         },

--- a/InteractiveHtmlBom/web/render.js
+++ b/InteractiveHtmlBom/web/render.js
@@ -310,6 +310,8 @@ function drawPadHole(ctx, pad, padHoleColor) {
   ctx.fillStyle = padHoleColor;
   if (pad.drillshape == "oblong") {
     ctx.fill(getOblongPath(pad.drillsize));
+  } else if (pad.drillshape == "rect") {
+    ctx.fill(getChamferedRectPath(pad.drillsize, 0, 0, 0));
   } else {
     ctx.fill(getCirclePath(pad.drillsize[0] / 2));
   }


### PR DESCRIPTION
Rectangle pad hole needs for Altium Design support and may be for other cads.