### PR TITLE
Separate style from logic, transfer the canvas property display to CSS

### DIFF
--- a/InteractiveHtmlBom/web/ibom.css
+++ b/InteractiveHtmlBom/web/ibom.css
@@ -869,6 +869,18 @@ a {
   padding: 0;
 }
 
+/* Layout states */
+#topmostdiv {
+  display: flex;
+  height: 100%;
+}
+#topmostdiv[data-layout-type="bom-only"] #frontcanvas { display: none; }
+#topmostdiv[data-layout-type="bom-only"] #backcanvas { display: none; }
+#topmostdiv[data-layout-type="bom-only"] {
+  display: block;
+  height: auto;
+}
+
 /* removes default styling from input color element */
 ::-webkit-color-swatch {
   border: none;

--- a/InteractiveHtmlBom/web/ibom.js
+++ b/InteractiveHtmlBom/web/ibom.js
@@ -935,6 +935,7 @@ function populateMetadata() {
 }
 
 function changeBomLayout(layout) {
+  document.getElementById("topmostdiv").setAttribute('data-layout-type', layout);
   document.getElementById("bom-btn").classList.remove("depressed");
   document.getElementById("lr-btn").classList.remove("depressed");
   document.getElementById("tb-btn").classList.remove("depressed");
@@ -947,17 +948,9 @@ function changeBomLayout(layout) {
         canvassplit.destroy();
         canvassplit = null;
       }
-      document.getElementById("frontcanvas").style.display = "none";
-      document.getElementById("backcanvas").style.display = "none";
-      document.getElementById("topmostdiv").style.height = "";
-      document.getElementById("topmostdiv").style.display = "block";
       break;
     case 'top-bottom':
       document.getElementById("tb-btn").classList.add("depressed");
-      document.getElementById("frontcanvas").style.display = "";
-      document.getElementById("backcanvas").style.display = "";
-      document.getElementById("topmostdiv").style.height = "100%";
-      document.getElementById("topmostdiv").style.display = "flex";
       document.getElementById("bomdiv").classList.remove("split-horizontal");
       document.getElementById("canvasdiv").classList.remove("split-horizontal");
       document.getElementById("frontcanvas").classList.add("split-horizontal");
@@ -982,10 +975,6 @@ function changeBomLayout(layout) {
       break;
     case 'left-right':
       document.getElementById("lr-btn").classList.add("depressed");
-      document.getElementById("frontcanvas").style.display = "";
-      document.getElementById("backcanvas").style.display = "";
-      document.getElementById("topmostdiv").style.height = "100%";
-      document.getElementById("topmostdiv").style.display = "flex";
       document.getElementById("bomdiv").classList.add("split-horizontal");
       document.getElementById("canvasdiv").classList.add("split-horizontal");
       document.getElementById("frontcanvas").classList.remove("split-horizontal");


### PR DESCRIPTION
While sorting through the web folder, I discovered that the script mixed functional actions with style design.

* transferred the display style to CSS;
* specified in attributes as a state, a separate class would not be logical;
* tried to preserve the old standard for old browsers.