### PR TITLE
Fix data for sort column value by ref

### DIFF
--- a/InteractiveHtmlBom/web/ibom.js
+++ b/InteractiveHtmlBom/web/ibom.js
@@ -362,6 +362,25 @@ function highlightFilter(s) {
   return r;
 }
 
+function getSelectedBomList() {
+  if (settings.bommode == "netlist") {
+    return pcbdata.nets.slice();
+  }
+  var out = [];
+  switch (settings.canvaslayout) {
+    case 'F':
+      out = pcbdata.bom.F.slice();
+      break;
+    case 'FB':
+      out = pcbdata.bom.both.slice();
+      break;
+    case 'B':
+      out = pcbdata.bom.B.slice();
+      break;
+  }
+  return (settings.bommode == "ungrouped") ? out.flat() : out;
+}
+
 function checkboxSetUnsetAllHandler(checkboxname) {
   return function () {
     var checkboxnum = 0;
@@ -619,31 +638,9 @@ function populateBomBody(placeholderColumn = null, placeHolderElements = null) {
   var first = true;
   var style = getComputedStyle(topmostdiv);
   var defaultNetColor = style.getPropertyValue('--track-color').trim();
-  if (settings.bommode == "netlist") {
-    bomtable = pcbdata.nets.slice();
-  } else {
-    switch (settings.canvaslayout) {
-      case 'F':
-        bomtable = pcbdata.bom.F.slice();
-        break;
-      case 'FB':
-        bomtable = pcbdata.bom.both.slice();
-        break;
-      case 'B':
-        bomtable = pcbdata.bom.B.slice();
-        break;
-    }
-    if (settings.bommode == "ungrouped") {
-      // expand bom table
-      expandedTable = []
-      for (var bomentry of bomtable) {
-        for (var ref of bomentry) {
-          expandedTable.push([ref]);
-        }
-      }
-      bomtable = expandedTable;
-    }
-  }
+  
+  bomtable = getSelectedBomList();
+
   if (bomSortFunction) {
     bomtable = bomtable.sort(bomSortFunction);
   }
@@ -1294,10 +1291,10 @@ function topToggle() {
 }
 
 window.onload = function (e) {
-  initUtils();
   initRender();
   initStorage();
   initDefaults();
+  initUtils();
   cleanGutters();
   populateMetadata();
   dbgdiv = document.getElementById("dbg");

--- a/InteractiveHtmlBom/web/ibom.js
+++ b/InteractiveHtmlBom/web/ibom.js
@@ -362,11 +362,6 @@ function highlightFilter(s) {
   return r;
 }
 
-function findBomRefRowById(id) {
-  var allList = getBomListByLayer('FB').flat();
-  return allList.find(item => item[1] == Number(id)) || [];
-}
-
 function getBomListByLayer(layer) {
   switch (layer) {
     case 'F': return pcbdata.bom.F.slice();
@@ -653,7 +648,7 @@ function populateBomBody(placeholderColumn = null, placeHolderElements = null) {
   var first = true;
   var style = getComputedStyle(topmostdiv);
   var defaultNetColor = style.getPropertyValue('--track-color').trim();
-  
+
   bomtable = getSelectedBomList();
 
   if (bomSortFunction) {

--- a/InteractiveHtmlBom/web/ibom.js
+++ b/InteractiveHtmlBom/web/ibom.js
@@ -378,7 +378,19 @@ function getSelectedBomList() {
       out = pcbdata.bom.B.slice();
       break;
   }
-  return (settings.bommode == "ungrouped") ? out.flat() : out;
+
+  if (settings.bommode == "ungrouped") {
+    // expand bom table
+    var expandedTable = [];
+    for (var bomentry of out) {
+      for (var ref of bomentry) {
+        expandedTable.push([ref]);
+      }
+    }
+    return expandedTable;
+  }
+
+  return out;
 }
 
 function checkboxSetUnsetAllHandler(checkboxname) {

--- a/InteractiveHtmlBom/web/ibom.js
+++ b/InteractiveHtmlBom/web/ibom.js
@@ -362,22 +362,25 @@ function highlightFilter(s) {
   return r;
 }
 
+function findBomRefRowById(id) {
+  var allList = getBomListByLayer('FB').flat();
+  return allList.find(item => item[1] == Number(id)) || [];
+}
+
+function getBomListByLayer(layer) {
+  switch (layer) {
+    case 'F': return pcbdata.bom.F.slice();
+    case 'B': return pcbdata.bom.B.slice();
+    case 'FB': return pcbdata.bom.both.slice();
+  }
+  return [];
+}
+
 function getSelectedBomList() {
   if (settings.bommode == "netlist") {
     return pcbdata.nets.slice();
   }
-  var out = [];
-  switch (settings.canvaslayout) {
-    case 'F':
-      out = pcbdata.bom.F.slice();
-      break;
-    case 'FB':
-      out = pcbdata.bom.both.slice();
-      break;
-    case 'B':
-      out = pcbdata.bom.B.slice();
-      break;
-  }
+  var out = getBomListByLayer(settings.canvaslayout);
 
   if (settings.bommode == "ungrouped") {
     // expand bom table

--- a/InteractiveHtmlBom/web/util.js
+++ b/InteractiveHtmlBom/web/util.js
@@ -208,7 +208,7 @@ function initUtils() {
     pcbdata.bom["parsedValues"] = {};
     var bomList = getSelectedBomList().flat();
     for (var id in pcbdata.bom.fields) {
-      var ref_row = bomList.find(item => item[1] == id) || [];
+      var ref_row = bomList.find(item => item[1] == Number(id)) || [];
       pcbdata.bom.parsedValues[id] = parseValue(pcbdata.bom.fields[id][index], ref_row[0] ||'');
     }
   }

--- a/InteractiveHtmlBom/web/util.js
+++ b/InteractiveHtmlBom/web/util.js
@@ -240,7 +240,7 @@ function parseValue(val, ref) {
     var val_i = parseFloat(match[1]);
     if (!unit) return null;
     if (match[2]) {
-      val_i = val_i * getMultiplier(match[2]);
+      val_i = val_i * units.getMultiplier(match[2]);
     }
     return {
       val: val_i,
@@ -255,7 +255,7 @@ function parseValue(val, ref) {
     var val_i = parseFloat(match[1] + "." + match[4]);
     if (!unit) return null;
     if (match[3]) {
-      val_i = val_i * getMultiplier(match[3]);
+      val_i = val_i * units.getMultiplier(match[3]);
     }
     return {
       val: val_i,

--- a/InteractiveHtmlBom/web/util.js
+++ b/InteractiveHtmlBom/web/util.js
@@ -206,10 +206,9 @@ function initUtils() {
   if (config.fields.includes("Value")) {
     var index = config.fields.indexOf("Value");
     pcbdata.bom["parsedValues"] = {};
-    var bomList = getSelectedBomList().flat();
     for (var id in pcbdata.bom.fields) {
-      var ref_row = bomList.find(item => item[1] == Number(id)) || [];
-      pcbdata.bom.parsedValues[id] = parseValue(pcbdata.bom.fields[id][index], ref_row[0] ||'');
+      var ref_key = findBomRefRowById(id)[0] ||'';
+      pcbdata.bom.parsedValues[id] = parseValue(pcbdata.bom.fields[id][index], ref_key);
     }
   }
 }

--- a/InteractiveHtmlBom/web/util.js
+++ b/InteractiveHtmlBom/web/util.js
@@ -206,8 +206,10 @@ function initUtils() {
   if (config.fields.includes("Value")) {
     var index = config.fields.indexOf("Value");
     pcbdata.bom["parsedValues"] = {};
+    var bomList = getSelectedBomList().flat();
     for (var id in pcbdata.bom.fields) {
-      pcbdata.bom.parsedValues[id] = parseValue(pcbdata.bom.fields[id][index])
+      var ref_row = bomList.find(item => item[1] == id) || [];
+      pcbdata.bom.parsedValues[id] = parseValue(pcbdata.bom.fields[id][index], ref_row[0] ||'');
     }
   }
 }

--- a/InteractiveHtmlBom/web/util.js
+++ b/InteractiveHtmlBom/web/util.js
@@ -221,45 +221,44 @@ function parseValue(val, ref) {
       if (unit == 'Ω' || unit == "ohm" || unit == "ohms") {
         unit = 'r';
       }
-      unit = unit[0];
-    } else {
-      ref = /^([a-z]+)\d+$/i.exec(ref);
-      if (ref) {
-        ref = ref[1].toLowerCase();
-        if (ref == "c") unit = 'f';
-        else if (ref == "l") unit = 'h';
-        else if (ref == "r" || ref == "rv") unit = 'r';
-        else unit = null;
-      }
+      return unit[0];
     }
-    return unit;
+
+    var resarr = /^([a-z]+)\d+$/i.exec(ref);
+    switch (Array.isArray(resarr) && resarr[1].toLowerCase()) {
+      case "c": return 'f';
+      case "l": return 'h';
+      case "r":
+      case "rv": return 'r';
+    }
+    return null;
   };
   val = val.replace(/,/g, "");
   var match = units.valueRegex.exec(val);
-  var unit;
-  if (match) {
-    val = parseFloat(match[1]);
-    if (match[2]) {
-      val = val * units.getMultiplier(match[2]);
-    }
-    unit = inferUnit(match[3], ref);
+  if (Array.isArray(match)) {
+    var unit = inferUnit(match[3], ref);
+    var val_i = parseFloat(match[1]);
     if (!unit) return null;
-    else return {
-      val: val,
+    if (match[2]) {
+      val_i = val_i * getMultiplier(match[2]);
+    }
+    return {
+      val: val_i,
       unit: unit,
       extra: match[4],
     }
   }
+
   match = units.valueAltRegex.exec(val);
-  if (match && (match[1] || match[4])) {
-    val = parseFloat(match[1] + "." + match[4]);
-    if (match[3]) {
-      val = val * units.getMultiplier(match[3]);
-    }
-    unit = inferUnit(match[2], ref);
+  if (Array.isArray(match) && (match[1] || match[4])) {
+    var unit = inferUnit(match[2], ref);
+    var val_i = parseFloat(match[1] + "." + match[4]);
     if (!unit) return null;
-    else return {
-      val: val,
+    if (match[3]) {
+      val_i = val_i * getMultiplier(match[3]);
+    }
+    return {
+      val: val_i,
       unit: unit,
       extra: match[5],
     }


### PR DESCRIPTION
This fix follows from the case described [here](https://github.com/openscopeproject/InteractiveHtmlBom/pull/494). Specifically, it fixes a missing attribute that was missed in the pull request: 

https://github.com/openscopeproject/InteractiveHtmlBom/commit/fecad4b92cc359e9825dd1df34a0e34f5fe43192#diff-de2364b729414cd00cfd23a25e62a71f55aaffac0f9f317defd0e767abc33ab0R184


For better understanding, below is a more detailed script:
```typescript
import config from './DataConfig.js';

export type column_value_t = {
    val: number,
    unit: string | null,
    extra: string | undefined,
};

type RefBOMItem = [string, number];

declare const window: {
    pcbdata: {
        nets: string[],
        bom: {
            fields: Record<string, string[]>,
            parsedValues: Record<string, column_value_t | null>,

            both: RefBOMItem[][],
            F: RefBOMItem[][],
            B: RefBOMItem[][],
        }
    },
    /** @note return `typeof window.pcbdata.nets` is not taken into account in this case */
    getSelectedBomList:()=> typeof window.pcbdata.bom.both | typeof window.pcbdata.bom.F | typeof window.pcbdata.bom.B,
};

const units = {
    prefixes: {
        giga: ["G", "g", "giga", "Giga", "GIGA"],
        mega: ["M", "mega", "Mega", "MEGA"],
        kilo: ["K", "k", "kilo", "Kilo", "KILO"],
        milli: ["m", "milli", "Milli", "MILLI"],
        micro: ["U", "u", "micro", "Micro", "MICRO", "μ", "µ"], // different utf8 μ
        nano: ["N", "n", "nano", "Nano", "NANO"],
        pico: ["P", "p", "pico", "Pico", "PICO"],
    },
    unitsShort: ["R", "r", "Ω", "F", "f", "H", "h"],
    unitsLong: [
        "OHM", "Ohm", "ohm", "ohms",
        "FARAD", "Farad", "farad",
        "HENRY", "Henry", "henry"
    ],
    valueRegex: <null | RegExp> null,
    valueAltRegex: <null | RegExp> null,
};

const getMultiplier = (s:string):number => {
    if (units.prefixes.giga.includes(s)) return 1e9;
    if (units.prefixes.mega.includes(s)) return 1e6;
    if (units.prefixes.kilo.includes(s)) return 1e3;
    if (units.prefixes.milli.includes(s)) return 1e-3;
    if (units.prefixes.micro.includes(s)) return 1e-6;
    if (units.prefixes.nano.includes(s)) return 1e-9;
    if (units.prefixes.pico.includes(s)) return 1e-12;
    return 1;
}

const inferUnit = (unit:string|undefined, ref:string):string|null => {
    if (unit) {
        unit = unit.toLowerCase();
        if (unit == 'Ω' || unit == "ohm" || unit == "ohms") {
            unit = 'r';
        }
        return unit[0];
    }

    const resarr: RegExpExecArray | null = /^([a-z]+)\d+$/i.exec(ref);
    switch(Array.isArray(resarr) && resarr[1].toLowerCase()) {
        case "c": return 'f';
        case "l": return 'h';
        case "r":
        case "rv": return 'r';
    }
    return null;
};

const parseValue:(val:string, ref:string)=> null | column_value_t = (val, ref) => {
    val = val.replace(/,/g, "");

    let match:RegExpExecArray|null = units.valueRegex!.exec(val);
    if (Array.isArray(match)) {
        const unit:string|null = inferUnit(match[3], ref);
        let val_i = parseFloat(match[1]);
        if (!unit) return null;
        if (match[2]) {
            val_i = val_i * getMultiplier(match[2]);
        }
        return {
            val: val_i,
            unit: unit,
            extra: match[4],
        }
    }

    match = units.valueAltRegex!.exec(val);
    if (Array.isArray(match) && (match[1] || match[4])) {
        const unit:string|null = inferUnit(match[2], ref);
        let val_i = parseFloat(match[1] + "." + match[4]);
        if (!unit) return null;
        if (match[3]) {
            val_i = val_i * getMultiplier(match[3]);
        }
        return {
            val: val_i,
            unit: unit,
            extra: match[5],
        }
    }
    return null;
};

export default () => {
    // можно тоже перенести
    const allPrefixes = units.prefixes.giga
        .concat(units.prefixes.mega)
        .concat(units.prefixes.kilo)
        .concat(units.prefixes.milli)
        .concat(units.prefixes.micro)
        .concat(units.prefixes.nano)
        .concat(units.prefixes.pico);
    const allUnits = units.unitsShort.concat(units.unitsLong);

    units.valueRegex = <RegExp>new RegExp("^([0-9\.]+)" +
        "\\s*(" + allPrefixes.join("|") + ")?" +
        "(" + allUnits.join("|") + ")?" +
        "(\\b.*)?$", "");
    units.valueAltRegex = new RegExp("^([0-9]*)" +
        "(" + units.unitsShort.join("|") + ")?" +
        "([GgMmKkUuNnPp])?" +
        "([0-9]*)" +
        "(\\b.*)?$", "");
    if (config.fields.includes("Value")) {
        const index = config.fields.indexOf("Value");
        const bomList:RefBOMItem[] = window.getSelectedBomList().flat();

        window.pcbdata.bom.parsedValues = {};
        
        for (let id in window.pcbdata.bom.fields) {
            const ref_row:RefBOMItem|[] = bomList.find((item:RefBOMItem) => item[1] == Number(id)) || [];
            window.pcbdata.bom.parsedValues[id] = parseValue(window.pcbdata.bom.fields[id][index], ref_row[0] || '');
        }
    }
}
```