### PR TITLE
fix for incorrect argument being passed

### DIFF
--- a/InteractiveHtmlBom/web/util.js
+++ b/InteractiveHtmlBom/web/util.js
@@ -209,7 +209,7 @@ function initUtils() {
     var allList = getBomListByLayer('FB').flat();
     for (var id in pcbdata.bom.fields) {
       var ref_key = allList.find(item => item[1] == Number(id)) || [];
-      pcbdata.bom.parsedValues[id] = parseValue(pcbdata.bom.fields[id][index], ref_key);
+      pcbdata.bom.parsedValues[id] = parseValue(pcbdata.bom.fields[id][index], ref_key[0] || '');
     }
   }
 }

--- a/InteractiveHtmlBom/web/util.js
+++ b/InteractiveHtmlBom/web/util.js
@@ -183,6 +183,7 @@ var units = {
     return 1;
   },
   valueRegex: null,
+  valueAltRegex: null,
 }
 
 function initUtils() {


### PR DESCRIPTION
In my [commit](https://github.com/openscopeproject/InteractiveHtmlBom/pull/495/commits/cb0a0539e25fb1da3046ad0ee04aaf2b38529835#diff-de2364b729414cd00cfd23a25e62a71f55aaffac0f9f317defd0e767abc33ab0R210-R211), the function `findBomRefRowById` returned an array from which the reference key was extracted. As a result, the variable `ref_key` had a mandatory type of `string`. Subsequently, the function `findBomRefRowById` was removed, and the conversion of `ref_key` was lost, causing the `parseValue` function to receive an incorrect attribute that does not work.

This PR fixes this issue.