### PR TITLE
Add a test runner fixes and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+---
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  Build:
+    name: KiCAD ${{ matrix.kicad-version }}
+
+    strategy:
+      matrix:
+        os:
+          - Ubuntu
+        kicad-version:
+          - "8.0"
+          - "9.0"
+
+    runs-on: ${{ matrix.os }}-latest
+    container:
+      image: kicad/kicad:${{ matrix.kicad-version }}
+      options: --user root
+
+    steps:
+      - name: 💾 Check out repository
+        uses: actions/checkout@v4
+
+      - name: 🛠️ Set up build environment
+        shell: bash
+        run: |
+          apt update && apt install -y python3-pip
+          python3 -m pip install --break-system-packages --upgrade hatch
+
+      - name: 🔥 Test
+        run: hatch -v run pytest -vv tests
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 jobs:
@@ -26,16 +26,16 @@ jobs:
       options: --user root
 
     steps:
-      - name: 💾 Check out repository
+      - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: 🛠️ Set up build environment
+      - name: Set up build environment
         shell: bash
         run: |
           apt update && apt install -y python3-pip
           python3 -m pip install --break-system-packages --upgrade hatch
 
-      - name: 🔥 Test
+      - name: Test
         run: hatch -v run pytest -vv tests
 
 concurrency:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ path = "InteractiveHtmlBom/version.py"
 pattern = "LAST_TAG = 'v(?P<version>[^']+)'"
 
 [tool.hatch.envs.default]
+system-packages = true
 dependencies = ["coverage[toml]>=6.5", "pytest"]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,11 @@ pattern = "LAST_TAG = 'v(?P<version>[^']+)'"
 
 [tool.hatch.envs.default]
 system-packages = true
-dependencies = ["coverage[toml]>=6.5", "pytest"]
+dependencies = [
+  "coverage[toml]>=6.5",
+  "pytest",
+  "pytest-sugar"
+]
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests}"
 test-cov = "coverage run -m pytest {args:tests}"

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,0 +1,2 @@
+def test_module_import():
+    import InteractiveHtmlBom  # noqa


### PR DESCRIPTION
This adds a basic CI workflow and some related fixups to allow `hatch test` to invoke Pytest properly. This PR adds a single test to ensure `import InteractiveHtmlBom` works (and that pytest can run the test).

Of note, this configures the default hatch environment in `pyproject.toml` to install with system site packages access. This allows the hatch-managed virtualenvs to access pcbnew and wxwidgets in the system site packages directory, which aren't installable in the hatch-managed environment.