### PR TITLE
Fix column name in optimization fumction entryMatches

### DIFF
--- a/InteractiveHtmlBom/web/ibom.js
+++ b/InteractiveHtmlBom/web/ibom.js
@@ -314,7 +314,7 @@ function entryMatches(entry) {
     return entry.toLowerCase().indexOf(filter) >= 0;
   }
   // check refs
-  if (!settings.hiddenColumns.includes("references")) {
+  if (!settings.hiddenColumns.includes("References")) {
     for (var ref of entry) {
       if (ref[0].toLowerCase().indexOf(filter) >= 0) {
         return true;


### PR DESCRIPTION
The optimization in the entryMatches() method was not functioning because a field with a different name was being checked. The field References must be used with an uppercase 'R', as it is defined as a required field here in this place:

https://github.com/openscopeproject/InteractiveHtmlBom/blob/master/InteractiveHtmlBom/web/util.js#L584-L589