### PR TITLE
Fix optimization in compare by reference name

### DIFF
--- a/InteractiveHtmlBom/web/ibom.js
+++ b/InteractiveHtmlBom/web/ibom.js
@@ -603,7 +603,7 @@ function populateBomHeader(placeHolderColumn = null, placeHolderElements = null)
         tr.appendChild(createColumnHeader("References", "references", (a, b) => {
           var i = 0;
           while (i < a.length && i < b.length) {
-            if (a[i] != b[i]) return compareRefs(a[i][0], b[i][0]);
+            if (a[i][0] != b[i][0]) return compareRefs(a[i][0], b[i][0]);
             i++;
           }
           return a.length - b.length;


### PR DESCRIPTION
In `JavaScript`, comparing arrays using the standard operator will not work. Since the sorting function later in the code only takes the `ReferenceName` into account, the comparison operator (which I assume is used for optimization) only compares based on the `ReferenceName`.
![image](https://github.com/user-attachments/assets/b02dd7f7-6925-4c19-9b13-f323306364b0)
