### PR TITLE
Make wx dependency optional for CLI usage

### DIFF
--- a/InteractiveHtmlBom/__init__.py
+++ b/InteractiveHtmlBom/__init__.py
@@ -3,11 +3,11 @@ import sys
 import threading
 import time
 
-import wx
-import wx.aui
+from .compat import get_wx
 
 
 def check_for_bom_button():
+    wx = get_wx()
     # From Miles McCoo's blog
     # https://kicad.mmccoo.com/2017/03/05/adding-your-own-command-buttons-to-the-pcbnew-gui/
     def find_pcbnew_window():

--- a/InteractiveHtmlBom/compat.py
+++ b/InteractiveHtmlBom/compat.py
@@ -1,0 +1,23 @@
+"""Compatibility utilities for optional wx dependency."""
+
+import os
+
+_wx = None
+
+
+def should_create_wx_app():
+    """Check if we should create a wx app based on environment."""
+    return 'INTERACTIVE_HTML_BOM_NO_DISPLAY' not in os.environ
+
+
+def get_wx():
+    """Get the wx module, or None if not available."""
+    global _wx
+    if _wx is not None:
+        return _wx
+    try:
+        import wx
+        _wx = wx
+        return _wx
+    except ImportError:
+        return None

--- a/InteractiveHtmlBom/core/config.py
+++ b/InteractiveHtmlBom/core/config.py
@@ -4,9 +4,7 @@ import argparse
 import os
 import re
 
-from wx import FileConfig
-
-from .. import dialog
+from ..compat import get_wx
 
 
 class Config:
@@ -107,7 +105,7 @@ class Config:
         else:
             return
 
-        f = FileConfig(localFilename=file)
+        f = get_wx().FileConfig(localFilename=file)
 
         f.SetPath('/html_defaults')
         self.dark_mode = f.ReadBool('dark_mode', self.dark_mode)
@@ -170,7 +168,7 @@ class Config:
     def save(self, locally):
         file = self.local_config_file if locally else self.global_config_file
         print('Saving to', file)
-        f = FileConfig(localFilename=file)
+        f = get_wx().FileConfig(localFilename=file)
 
         f.SetPath('/html_defaults')
         f.WriteBool('dark_mode', self.dark_mode)

--- a/InteractiveHtmlBom/core/ibom.py
+++ b/InteractiveHtmlBom/core/ibom.py
@@ -8,13 +8,11 @@ import re
 import sys
 from datetime import datetime
 
-import wx
-
 from . import units
 from .config import Config
-from ..dialog import SettingsDialog
 from ..ecad.common import EcadParser, Component
 from ..errors import ParsingException
+from ..compat import get_wx
 
 
 class Logger(object):
@@ -38,13 +36,13 @@ class Logger(object):
         if self.cli:
             self.logger.error(msg)
         else:
-            wx.MessageBox(msg)
+            get_wx().MessageBox(msg)
 
     def warn(self, msg):
         if self.cli:
             self.logger.warning(msg)
         else:
-            wx.LogWarning(msg)
+            get_wx().LogWarning(msg)
 
 
 log = None
@@ -341,6 +339,8 @@ def main(parser, config, logger):
 
 def run_with_dialog(parser, config, logger):
     # type: (EcadParser, Config, Logger) -> None
+    from ..dialog import SettingsDialog
+
     def save_config(dialog_panel, locally=False):
         config.set_from_dialog(dialog_panel)
         config.save(locally)
@@ -358,7 +358,7 @@ def run_with_dialog(parser, config, logger):
         if extra_data_file is not None:
             dlg.set_extra_data_path(extra_data_file)
         config.transfer_to_dialog(dlg.panel)
-        if dlg.ShowModal() == wx.ID_OK:
+        if dlg.ShowModal() == get_wx().ID_OK:
             config.set_from_dialog(dlg.panel)
             main(parser, config, logger)
     finally:

--- a/InteractiveHtmlBom/generate_interactive_bom.py
+++ b/InteractiveHtmlBom/generate_interactive_bom.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import argparse
 import os
 import sys
+
 # Add ../ to the path
 # Works if this script is executed without installing the module
 script_dir = os.path.dirname(os.path.abspath(os.path.realpath(__file__)))
@@ -23,22 +24,29 @@ def to_utf(s):
 
 
 def main():
-    create_wx_app = 'INTERACTIVE_HTML_BOM_NO_DISPLAY' not in os.environ
+    from .compat import get_wx, should_create_wx_app
+    wx = get_wx()
+    create_wx_app = should_create_wx_app()
 
-    import wx
+    if wx is None and create_wx_app:
+        print("wxpython is required unless INTERACTIVE_HTML_BOM_NO_DISPLAY "
+              "environment variable is set")
+        sys.exit(1)
 
-    if create_wx_app:
-        app = wx.App()
-        if hasattr(wx, "APP_ASSERT_SUPPRESS"):
-            app.SetAssertMode(wx.APP_ASSERT_SUPPRESS)
-    elif hasattr(wx, "DisableAsserts"):
-        wx.DisableAsserts()
+    if wx is not None:
+        if create_wx_app:
+            app = wx.App()
+            if hasattr(wx, "APP_ASSERT_SUPPRESS"):
+                app.SetAssertMode(wx.APP_ASSERT_SUPPRESS)
+        elif hasattr(wx, "DisableAsserts"):
+            wx.DisableAsserts()
 
     from .core import ibom
     from .core.config import Config
     from .ecad import get_parser_by_extension
     from .version import version
     from .errors import (ExitCodes, ParsingException, exit_error)
+
 
     parser = argparse.ArgumentParser(
             description='KiCad InteractiveHtmlBom plugin CLI.',


### PR DESCRIPTION
wxPython is kinda annoying/needy to install, and the way the imports are currently make it tough to use headless w/o installing a bunch of extra stuff. This PR uses an existing environment variable to gate the import of `wx` to areas of the code that actually use GUI elements. 

## Quick summary of changes:
- Add `get_wx()` in `compat.py` to gate wx imports behind `INTERACTIVE_HTML_BOM_NO_DISPLAY` environment variable
- Allows headless HTML BOM generation without wxPython installed
- GUI features like `--show-dialog` still require wx

## Usage
```bash
INTERACTIVE_HTML_BOM_NO_DISPLAY=1 python -m InteractiveHtmlBom.generate_interactive_bom board.kicad_pcb --no-browser
```