### PR TITLE
Fix plugin error when pad layer set is empty under KiCad 10

### DIFF
--- a/InteractiveHtmlBom/ecad/kicad.py
+++ b/InteractiveHtmlBom/ecad/kicad.py
@@ -494,6 +494,8 @@ class PcbnewParser(EcadParser):
                     pads.append(pad_dict)
             return pads
         else:
+            if not layers_set:
+                return []
             pad_dict = self.parse_pad_layer(pad, layers_set[0])
             pad_dict["layers"] = layers
             return [pad_dict]


### PR DESCRIPTION
KiCad 10 returns non-indexable layer set objects for some pads, causing  'layers_set[0]' to raise IndexError. Add a guard to skip pads with empty or invalid layer sets.