### PR TITLE
use GetDNPForVariant() as canonical source for DNP flag

### DIFF
--- a/InteractiveHtmlBom/ecad/kicad.py
+++ b/InteractiveHtmlBom/ecad/kicad.py
@@ -62,7 +62,10 @@ class PcbnewParser(EcadParser):
         if "dnp" in props and props["dnp"] == "":
             del props["dnp"]
             props["kicad_dnp"] = "DNP"
-        if hasattr(f, "IsDNP"):
+        if hasattr(f, 'GetDNPForVariant'):
+            if f.GetDNPForVariant(self.config.kicad_variant):
+                props["kicad_dnp"] = "DNP"
+        elif hasattr(f, "IsDNP"):
             if f.IsDNP():
                 props["kicad_dnp"] = "DNP"
         if hasattr(f, 'GetVariant'):
@@ -71,8 +74,6 @@ class PcbnewParser(EcadParser):
                 var_fields = variant.GetFields()
                 for k in var_fields.keys():
                     props[str(k)] = str(f.GetFieldShownText(str(k)))
-                if variant.GetDNP():
-                    props["kicad_dnp"] = "DNP"
 
         return props
 


### PR DESCRIPTION
the KiCad DNP flag was not reset when a variant overrides the flag to false from the default variant (base) value. this lead to a footprint marked as DNP in the iBOM (and possiply wrongfully excluded) if the base value for the DNP flag is true while the variant's DNP flag is false.

instead of fiddling with custom logic, this change uses KiCad's `GetDNPForVariant()`. that is available in v10 KiCad. it will resolve to the canonical DNP flag for that footprint in the given variant.

only if `GetDNPForVariant()` is not available, `IsDNP()` will be used as fallback (KiCad v9 or older).