### PR TITLE
Add ini configuration parsing

### DIFF
--- a/InteractiveHtmlBom/core/config.py
+++ b/InteractiveHtmlBom/core/config.py
@@ -454,9 +454,9 @@ class Config:
                                  'do not populate status. Components with '
                                  'this field not empty will be excluded.')
 
-    def set_from_args_with_ini(self, args):
+    def set_from_args_with_ini(self, args, cli_provided=frozenset()):
+        # type: (argparse.Namespace, frozenset) -> None
         import configparser
-        import math
         import sys
 
         from ..errors import ExitCodes
@@ -472,99 +472,127 @@ class Config:
         config = configparser.ConfigParser()
         config.read(file)
 
+        # Start from the command line arguments (and their defaults). Any option
+        # explicitly passed on the command line takes precedence over the ini
+        # file; the ini only fills in options the user did not specify.
+        self.set_from_args(args)
+
         # Html
-        self.dark_mode = config.getboolean('html_defaults', 'dark_mode',
-                                           fallback=args.dark_mode)
-        self.show_pads = config.getboolean('html_defaults', 'show_pads',
-                                           fallback=not args.hide_pads)
-        self.show_fabrication = config.getboolean('html_defaults',
-                                                  'show_fabrication',
-                                                  fallback=args.show_fabrication)
-        self.show_silkscreen = config.getboolean('html_defaults', 'show_silkscreen',
-                                                 fallback=not args.hide_silkscreen)
-        self.highlight_pin1 = config.get('html_defaults', 'highlight_pin1',
-                                         fallback=args.highlight_pin1)
-        # migration from previous settings
-        if self.highlight_pin1 == '0':
-            self.highlight_pin1 = 'none'
-        if self.highlight_pin1 == '1':
-            self.highlight_pin1 = 'all'
-        self.redraw_on_drag = config.getboolean('html_defaults',
-                                                'redraw_on_drag',
-                                                fallback=not args.no_redraw_on_drag)
-        self.board_rotation = config.getint(
-            'html_defaults', 'board_rotation',
-            fallback=math.fmod(args.board_rotation // 5, 37))
-        self.offset_back_rotation = config.getboolean(
-            'html_defaults', 'offset_back_rotation',
-            fallback=args.offset_back_rotation)
-        self.checkboxes = config.get('html_defaults', 'checkboxes',
-                                     fallback=args.checkboxes)
-        self.mark_when_checked = config.get('html_defaults',
-                                            'mark_when_checked',
-                                            fallback=args.mark_when_checked)
-        self.bom_view = config.get('html_defaults', 'bom_view',
-                                   fallback=args.bom_view)
-        self.layer_view = config.get('html_defaults', 'layer_view',
-                                     fallback=args.layer_view)
-        self.compression = config.getboolean('html_defaults', 'compression',
-                                             fallback=not args.no_compression)
-        self.open_browser = config.getboolean('html_defaults', 'open_browser',
-                                              fallback=not args.no_browser)
+        if 'dark_mode' not in cli_provided:
+            self.dark_mode = config.getboolean('html_defaults', 'dark_mode',
+                                               fallback=self.dark_mode)
+        if 'hide_pads' not in cli_provided:
+            self.show_pads = config.getboolean('html_defaults', 'show_pads',
+                                               fallback=self.show_pads)
+        if 'show_fabrication' not in cli_provided:
+            self.show_fabrication = config.getboolean('html_defaults',
+                                                      'show_fabrication',
+                                                      fallback=self.show_fabrication)
+        if 'hide_silkscreen' not in cli_provided:
+            self.show_silkscreen = config.getboolean('html_defaults',
+                                                     'show_silkscreen',
+                                                     fallback=self.show_silkscreen)
+        if 'highlight_pin1' not in cli_provided:
+            self.highlight_pin1 = config.get('html_defaults', 'highlight_pin1',
+                                             fallback=self.highlight_pin1)
+            # migration from previous settings
+            if self.highlight_pin1 == '0':
+                self.highlight_pin1 = 'none'
+            if self.highlight_pin1 == '1':
+                self.highlight_pin1 = 'all'
+        if 'no_redraw_on_drag' not in cli_provided:
+            self.redraw_on_drag = config.getboolean('html_defaults',
+                                                    'redraw_on_drag',
+                                                    fallback=self.redraw_on_drag)
+        if 'board_rotation' not in cli_provided:
+            self.board_rotation = config.getint('html_defaults', 'board_rotation',
+                                                fallback=self.board_rotation)
+        if 'offset_back_rotation' not in cli_provided:
+            self.offset_back_rotation = config.getboolean(
+                'html_defaults', 'offset_back_rotation',
+                fallback=self.offset_back_rotation)
+        if 'checkboxes' not in cli_provided:
+            self.checkboxes = config.get('html_defaults', 'checkboxes',
+                                         fallback=self.checkboxes)
+        if 'mark_when_checked' not in cli_provided:
+            self.mark_when_checked = config.get('html_defaults',
+                                                'mark_when_checked',
+                                                fallback=self.mark_when_checked)
+        if 'bom_view' not in cli_provided:
+            self.bom_view = config.get('html_defaults', 'bom_view',
+                                       fallback=self.bom_view)
+        if 'layer_view' not in cli_provided:
+            self.layer_view = config.get('html_defaults', 'layer_view',
+                                         fallback=self.layer_view)
+        if 'no_compression' not in cli_provided:
+            self.compression = config.getboolean('html_defaults', 'compression',
+                                                 fallback=self.compression)
+        if 'no_browser' not in cli_provided:
+            self.open_browser = config.getboolean('html_defaults', 'open_browser',
+                                                  fallback=self.open_browser)
 
         # General
-        self.bom_dest_dir = config.get('general', 'bom_dest_dir',
-                                       fallback=args.dest_dir)
-        self.bom_name_format = config.get('general', 'bom_name_format',
-                                          fallback=args.name_format)
-        self.component_sort_order = self._split(
-            config.get('general', 'component_sort_order',
-                       fallback=args.sort_order)
-        )
-        self.component_blacklist = self._split(
-            config.get('general',
-                       'component_blacklist',
-                       fallback=args.blacklist)
-        )
-        self.blacklist_virtual = config.getboolean('general',
-                                                   'blacklist_virtual',
-                                                   fallback=not args.no_blacklist_virtual)
-        self.blacklist_empty_val = config.getboolean(
-            'general', 'blacklist_empty_val',
-            fallback=args.blacklist_empty_val)
-        self.include_tracks = config.getboolean('general', 'include_tracks',
-                                                fallback=args.include_tracks)
-        self.include_nets = config.getboolean('general', 'include_nets',
-                                              fallback=args.include_nets)
+        if 'dest_dir' not in cli_provided:
+            self.bom_dest_dir = config.get('general', 'bom_dest_dir',
+                                           fallback=self.bom_dest_dir)
+        if 'name_format' not in cli_provided:
+            self.bom_name_format = config.get('general', 'bom_name_format',
+                                              fallback=self.bom_name_format)
+        if 'sort_order' not in cli_provided:
+            self.component_sort_order = self._split(config.get(
+                'general', 'component_sort_order',
+                fallback=self._join(self.component_sort_order)))
+        if 'blacklist' not in cli_provided:
+            self.component_blacklist = self._split(config.get(
+                'general', 'component_blacklist',
+                fallback=self._join(self.component_blacklist)))
+        if 'no_blacklist_virtual' not in cli_provided:
+            self.blacklist_virtual = config.getboolean(
+                'general', 'blacklist_virtual',
+                fallback=self.blacklist_virtual)
+        if 'blacklist_empty_val' not in cli_provided:
+            self.blacklist_empty_val = config.getboolean(
+                'general', 'blacklist_empty_val',
+                fallback=self.blacklist_empty_val)
+        if 'include_tracks' not in cli_provided:
+            self.include_tracks = config.getboolean('general', 'include_tracks',
+                                                    fallback=self.include_tracks)
+        if 'include_nets' not in cli_provided:
+            self.include_nets = config.getboolean('general', 'include_nets',
+                                                  fallback=self.include_nets)
 
         # Fields
-        self.extra_data_file = args.extra_data_file or args.netlist_file
-        if args.extra_fields is not None:
-            self.show_fields = self.default_show_group_fields + \
-                self._split(args.extra_fields)
-            self.group_fields = self.show_fields
-        else:
-            self.show_fields = self._split(
-                config.get('fields', 'show_fields', fallback=args.show_fields)
-            )
-            self.group_fields = self._split(
-                config.get('fields', 'group_fields',
-                           fallback=args.group_fields)
-            )
-        self.normalize_field_case = config.getboolean('fields',
-                                                      'normalize_field_case',
-                                                      fallback=args.normalize_field_case)
-        self.board_variant_field = config.get('fields', 'board_variant_field',
-                                              fallback=args.variant_field)
-        self.board_variant_whitelist = self._split(
-            config.get('fields', 'board_variant_whitelist',
-                       fallback=args.variants_whitelist)
-        )
-        self.board_variant_blacklist = self._split(
-            config.get('fields', 'board_variant_blacklist',
-                       fallback=args.variants_blacklist))
-        self.dnp_field = config.get('fields', 'dnp_field',
-                                    fallback=args.dnp_field)
+        # extra_data_file is intentionally not read from the ini; it is chosen
+        # dynamically unless explicitly given on the command line.
+        # show_fields/group_fields come from the ini only when the user did not
+        # override them (or --extra-fields) on the command line.
+        if 'extra_fields' not in cli_provided:
+            if 'show_fields' not in cli_provided:
+                self.show_fields = self._split(config.get(
+                    'fields', 'show_fields',
+                    fallback=self._join(self.show_fields)))
+            if 'group_fields' not in cli_provided:
+                self.group_fields = self._split(config.get(
+                    'fields', 'group_fields',
+                    fallback=self._join(self.group_fields)))
+        if 'normalize_field_case' not in cli_provided:
+            self.normalize_field_case = config.getboolean(
+                'fields', 'normalize_field_case',
+                fallback=self.normalize_field_case)
+        if 'variant_field' not in cli_provided:
+            self.board_variant_field = config.get('fields', 'board_variant_field',
+                                                  fallback=self.board_variant_field)
+        if 'variants_whitelist' not in cli_provided:
+            self.board_variant_whitelist = self._split(config.get(
+                'fields', 'board_variant_whitelist',
+                fallback=self._join(self.board_variant_whitelist)))
+        if 'variants_blacklist' not in cli_provided:
+            self.board_variant_blacklist = self._split(config.get(
+                'fields', 'board_variant_blacklist',
+                fallback=self._join(self.board_variant_blacklist)))
+        if 'dnp_field' not in cli_provided:
+            self.dnp_field = config.get('fields', 'dnp_field',
+                                        fallback=self.dnp_field)
 
     def set_from_args(self, args):
         # type: (argparse.Namespace) -> None

--- a/InteractiveHtmlBom/core/config.py
+++ b/InteractiveHtmlBom/core/config.py
@@ -82,6 +82,7 @@ class Config:
     board_variant_whitelist = []
     board_variant_blacklist = []
     dnp_field = ''
+    use_ini = False
 
     # this is cli only field
     kicad_variant = ''
@@ -390,6 +391,8 @@ class Config:
                             action='store_true')
         parser.add_argument('--no-browser', help='Do not launch browser.',
                             action='store_true')
+        parser.add_argument('--use-ini', help='Use all run options from ibom ini file.',
+                            action='store_true')
 
         # General
         parser.add_argument('--dest-dir', default=cls.bom_dest_dir,
@@ -450,6 +453,102 @@ class Config:
                             help='Name of the extra field that indicates '
                                  'do not populate status. Components with '
                                  'this field not empty will be excluded.')
+
+    def set_from_args_with_ini(self, args):
+        import configparser
+        import math
+
+        if os.path.isfile(self.local_config_file):
+            file = self.local_config_file
+        elif os.path.isfile(self.global_config_file):
+            file = self.global_config_file
+        else:
+            print("Error! No ini file in usual locations")
+            exit(0)
+
+        config = configparser.ConfigParser()
+        config.read(file)
+
+        # Html
+        self.dark_mode = config.getboolean('html_defaults', 'dark_mode',
+                                           fallback=args.dark_mode)
+        self.show_pads = config.getboolean('html_defaults', 'show_pads',
+                                           fallback=not args.hide_pads)
+        self.show_fabrication = config.getboolean('html_defaults',
+                                                  'show_fabrication',
+                                                  fallback=args.show_fabrication)
+        self.show_silkscreen = config.getboolean('html_defaults', 'show_silkscreen',
+                                                 fallback=not args.hide_silkscreen)
+        self.highlight_pin1 = config.getboolean('html_defaults', 'highlight_pin1',
+                                                fallback=args.highlight_pin1)
+        self.redraw_on_drag = config.getboolean('html_defaults',
+                                                'redraw_on_drag',
+                                                fallback=not args.no_redraw_on_drag)
+        self.board_rotation = config.getfloat('html_defaults', 'board_rotation',
+                                              fallback=args.board_rotation)
+        self.checkboxes = config.get('html_defaults', 'checkboxes',
+                                     fallback=args.checkboxes)
+        self.bom_view = config.get('html_defaults', 'bom_view',
+                                   fallback=args.bom_view)
+        self.layer_view = config.get('html_defaults', 'layer_view',
+                                     fallback=args.layer_view)
+        self.compression = config.getboolean('html_defaults', 'compression',
+                                             fallback=not args.no_compression)
+        self.open_browser = config.getboolean('html_defaults', 'open_browser',
+                                              fallback=not args.no_browser)
+
+        # General
+        self.bom_dest_dir = config.get('general', 'bom_dest_dir',
+                                       fallback=args.dest_dir)
+        self.bom_name_format = config.get('general', 'bom_name_format',
+                                          fallback=args.name_format)
+        self.component_sort_order = self._split(
+            config.get('general', 'component_sort_order',
+                       fallback=args.sort_order)
+        )
+        self.component_blacklist = self._split(
+            config.get('general',
+                       'component_blacklist',
+                       fallback=args.blacklist)
+        )
+        self.blacklist_virtual = config.getboolean('general',
+                                                   'blacklist_virtual',
+                                                   fallback=not args.no_blacklist_virtual)
+        self.blacklist_empty_val = config.get('general', 'blacklist_empty_val',
+                                              fallback=args.blacklist_empty_val)
+        self.include_tracks = config.getboolean('general', 'include_tracks',
+                                                fallback=args.include_tracks)
+        self.include_nets = config.getboolean('general', 'include_nets',
+                                              fallback=args.include_nets)
+
+        # Fields
+        self.extra_data_file = args.extra_data_file or args.netlist_file
+        if args.extra_fields is not None:
+            self.show_fields = self.default_show_group_fields + \
+                self._split(args.extra_fields)
+            self.group_fields = self.show_fields
+        else:
+            self.show_fields = self._split(
+                config.get('fields', 'show_fields', fallback=args.show_fields)
+            )
+            self.group_fields = self._split(
+                config.get('fields', 'group_fields',
+                           fallback=args.group_fields)
+            )
+        self.normalize_field_case = config.getboolean('fields',
+                                                      'normalize_field_case',
+                                                      fallback=args.normalize_field_case)
+        self.board_variant_field = config.get('fields', 'board_variant_field',
+                                              fallback=args.variant_field)
+        self.board_variant_whitelist = self._split(
+            config.get('fields', 'board_variant_whitelist',
+                       fallback=args.variants_whitelist)
+        )
+        self.board_variant_blacklist = self._split(
+            config.get('fields', 'board_variant_blacklist',
+                       fallback=args.variants_blacklist))
+        self.dnp_field = config.get('fields', 'dnp_field',
+                                    fallback=args.dnp_field)
 
     def set_from_args(self, args):
         # type: (argparse.Namespace) -> None

--- a/InteractiveHtmlBom/core/config.py
+++ b/InteractiveHtmlBom/core/config.py
@@ -477,91 +477,84 @@ class Config:
         # file; the ini only fills in options the user did not specify.
         self.set_from_args(args)
 
-        # Html
-        if 'dark_mode' not in cli_provided:
-            self.dark_mode = config.getboolean('html_defaults', 'dark_mode',
-                                               fallback=self.dark_mode)
-        if 'hide_pads' not in cli_provided:
-            self.show_pads = config.getboolean('html_defaults', 'show_pads',
-                                               fallback=self.show_pads)
-        if 'show_fabrication' not in cli_provided:
-            self.show_fabrication = config.getboolean('html_defaults',
-                                                      'show_fabrication',
-                                                      fallback=self.show_fabrication)
-        if 'hide_silkscreen' not in cli_provided:
-            self.show_silkscreen = config.getboolean('html_defaults',
-                                                     'show_silkscreen',
-                                                     fallback=self.show_silkscreen)
-        if 'highlight_pin1' not in cli_provided:
-            self.highlight_pin1 = config.get('html_defaults', 'highlight_pin1',
-                                             fallback=self.highlight_pin1)
-            # migration from previous settings
-            if self.highlight_pin1 == '0':
-                self.highlight_pin1 = 'none'
-            if self.highlight_pin1 == '1':
-                self.highlight_pin1 = 'all'
-        if 'no_redraw_on_drag' not in cli_provided:
-            self.redraw_on_drag = config.getboolean('html_defaults',
-                                                    'redraw_on_drag',
-                                                    fallback=self.redraw_on_drag)
-        if 'board_rotation' not in cli_provided:
-            self.board_rotation = config.getint('html_defaults', 'board_rotation',
-                                                fallback=self.board_rotation)
-        if 'offset_back_rotation' not in cli_provided:
-            self.offset_back_rotation = config.getboolean(
-                'html_defaults', 'offset_back_rotation',
-                fallback=self.offset_back_rotation)
-        if 'checkboxes' not in cli_provided:
-            self.checkboxes = config.get('html_defaults', 'checkboxes',
-                                         fallback=self.checkboxes)
-        if 'mark_when_checked' not in cli_provided:
-            self.mark_when_checked = config.get('html_defaults',
-                                                'mark_when_checked',
-                                                fallback=self.mark_when_checked)
-        if 'bom_view' not in cli_provided:
-            self.bom_view = config.get('html_defaults', 'bom_view',
-                                       fallback=self.bom_view)
-        if 'layer_view' not in cli_provided:
-            self.layer_view = config.get('html_defaults', 'layer_view',
-                                         fallback=self.layer_view)
-        if 'no_compression' not in cli_provided:
-            self.compression = config.getboolean('html_defaults', 'compression',
-                                                 fallback=self.compression)
-        if 'no_browser' not in cli_provided:
-            self.open_browser = config.getboolean('html_defaults', 'open_browser',
-                                                  fallback=self.open_browser)
+        # Options that map directly between an ini key and a config attribute.
+        # Each entry is (section, key, attribute, kind, cli_dest); the ini value
+        # is used only when the matching command line option (cli_dest) was not
+        # explicitly provided, otherwise the value from set_from_args is kept.
+        ini_options = [
+            # Html
+            ('html_defaults', 'dark_mode', 'dark_mode', 'bool', 'dark_mode'),
+            ('html_defaults', 'show_pads', 'show_pads', 'bool', 'hide_pads'),
+            ('html_defaults', 'show_fabrication', 'show_fabrication', 'bool',
+             'show_fabrication'),
+            ('html_defaults', 'show_silkscreen', 'show_silkscreen', 'bool',
+             'hide_silkscreen'),
+            ('html_defaults', 'highlight_pin1', 'highlight_pin1', 'str',
+             'highlight_pin1'),
+            ('html_defaults', 'redraw_on_drag', 'redraw_on_drag', 'bool',
+             'no_redraw_on_drag'),
+            ('html_defaults', 'board_rotation', 'board_rotation', 'int',
+             'board_rotation'),
+            ('html_defaults', 'offset_back_rotation', 'offset_back_rotation',
+             'bool', 'offset_back_rotation'),
+            ('html_defaults', 'checkboxes', 'checkboxes', 'str', 'checkboxes'),
+            ('html_defaults', 'mark_when_checked', 'mark_when_checked', 'str',
+             'mark_when_checked'),
+            ('html_defaults', 'bom_view', 'bom_view', 'str', 'bom_view'),
+            ('html_defaults', 'layer_view', 'layer_view', 'str', 'layer_view'),
+            ('html_defaults', 'compression', 'compression', 'bool',
+             'no_compression'),
+            ('html_defaults', 'open_browser', 'open_browser', 'bool',
+             'no_browser'),
+            # General
+            ('general', 'bom_dest_dir', 'bom_dest_dir', 'str', 'dest_dir'),
+            ('general', 'bom_name_format', 'bom_name_format', 'str',
+             'name_format'),
+            ('general', 'component_sort_order', 'component_sort_order', 'list',
+             'sort_order'),
+            ('general', 'component_blacklist', 'component_blacklist', 'list',
+             'blacklist'),
+            ('general', 'blacklist_virtual', 'blacklist_virtual', 'bool',
+             'no_blacklist_virtual'),
+            ('general', 'blacklist_empty_val', 'blacklist_empty_val', 'bool',
+             'blacklist_empty_val'),
+            ('general', 'include_tracks', 'include_tracks', 'bool',
+             'include_tracks'),
+            ('general', 'include_nets', 'include_nets', 'bool', 'include_nets'),
+            # Fields (show_fields/group_fields handled separately below)
+            ('fields', 'normalize_field_case', 'normalize_field_case', 'bool',
+             'normalize_field_case'),
+            ('fields', 'board_variant_field', 'board_variant_field', 'str',
+             'variant_field'),
+            ('fields', 'board_variant_whitelist', 'board_variant_whitelist',
+             'list', 'variants_whitelist'),
+            ('fields', 'board_variant_blacklist', 'board_variant_blacklist',
+             'list', 'variants_blacklist'),
+            ('fields', 'dnp_field', 'dnp_field', 'str', 'dnp_field'),
+        ]
 
-        # General
-        if 'dest_dir' not in cli_provided:
-            self.bom_dest_dir = config.get('general', 'bom_dest_dir',
-                                           fallback=self.bom_dest_dir)
-        if 'name_format' not in cli_provided:
-            self.bom_name_format = config.get('general', 'bom_name_format',
-                                              fallback=self.bom_name_format)
-        if 'sort_order' not in cli_provided:
-            self.component_sort_order = self._split(config.get(
-                'general', 'component_sort_order',
-                fallback=self._join(self.component_sort_order)))
-        if 'blacklist' not in cli_provided:
-            self.component_blacklist = self._split(config.get(
-                'general', 'component_blacklist',
-                fallback=self._join(self.component_blacklist)))
-        if 'no_blacklist_virtual' not in cli_provided:
-            self.blacklist_virtual = config.getboolean(
-                'general', 'blacklist_virtual',
-                fallback=self.blacklist_virtual)
-        if 'blacklist_empty_val' not in cli_provided:
-            self.blacklist_empty_val = config.getboolean(
-                'general', 'blacklist_empty_val',
-                fallback=self.blacklist_empty_val)
-        if 'include_tracks' not in cli_provided:
-            self.include_tracks = config.getboolean('general', 'include_tracks',
-                                                    fallback=self.include_tracks)
-        if 'include_nets' not in cli_provided:
-            self.include_nets = config.getboolean('general', 'include_nets',
-                                                  fallback=self.include_nets)
+        getters = {
+            'bool': config.getboolean,
+            'int': config.getint,
+            'str': config.get,
+        }
+        for section, key, attr, kind, dest in ini_options:
+            if dest in cli_provided:
+                continue
+            current = getattr(self, attr)
+            if kind == 'list':
+                value = self._split(
+                    config.get(section, key, fallback=self._join(current)))
+            else:
+                value = getters[kind](section, key, fallback=current)
+            setattr(self, attr, value)
 
-        # Fields
+        # migration from previous settings
+        if self.highlight_pin1 == '0':
+            self.highlight_pin1 = 'none'
+        if self.highlight_pin1 == '1':
+            self.highlight_pin1 = 'all'
+
         # extra_data_file is intentionally not read from the ini; it is chosen
         # dynamically unless explicitly given on the command line.
         # show_fields/group_fields come from the ini only when the user did not
@@ -575,24 +568,6 @@ class Config:
                 self.group_fields = self._split(config.get(
                     'fields', 'group_fields',
                     fallback=self._join(self.group_fields)))
-        if 'normalize_field_case' not in cli_provided:
-            self.normalize_field_case = config.getboolean(
-                'fields', 'normalize_field_case',
-                fallback=self.normalize_field_case)
-        if 'variant_field' not in cli_provided:
-            self.board_variant_field = config.get('fields', 'board_variant_field',
-                                                  fallback=self.board_variant_field)
-        if 'variants_whitelist' not in cli_provided:
-            self.board_variant_whitelist = self._split(config.get(
-                'fields', 'board_variant_whitelist',
-                fallback=self._join(self.board_variant_whitelist)))
-        if 'variants_blacklist' not in cli_provided:
-            self.board_variant_blacklist = self._split(config.get(
-                'fields', 'board_variant_blacklist',
-                fallback=self._join(self.board_variant_blacklist)))
-        if 'dnp_field' not in cli_provided:
-            self.dnp_field = config.get('fields', 'dnp_field',
-                                        fallback=self.dnp_field)
 
     def set_from_args(self, args):
         # type: (argparse.Namespace) -> None

--- a/InteractiveHtmlBom/core/config.py
+++ b/InteractiveHtmlBom/core/config.py
@@ -457,6 +457,9 @@ class Config:
     def set_from_args_with_ini(self, args):
         import configparser
         import math
+        import sys
+
+        from ..errors import ExitCodes
 
         if os.path.isfile(self.local_config_file):
             file = self.local_config_file
@@ -464,7 +467,7 @@ class Config:
             file = self.global_config_file
         else:
             print("Error! No ini file in usual locations")
-            exit(0)
+            sys.exit(ExitCodes.ERROR_FILE_NOT_FOUND)
 
         config = configparser.ConfigParser()
         config.read(file)
@@ -479,15 +482,27 @@ class Config:
                                                   fallback=args.show_fabrication)
         self.show_silkscreen = config.getboolean('html_defaults', 'show_silkscreen',
                                                  fallback=not args.hide_silkscreen)
-        self.highlight_pin1 = config.getboolean('html_defaults', 'highlight_pin1',
-                                                fallback=args.highlight_pin1)
+        self.highlight_pin1 = config.get('html_defaults', 'highlight_pin1',
+                                         fallback=args.highlight_pin1)
+        # migration from previous settings
+        if self.highlight_pin1 == '0':
+            self.highlight_pin1 = 'none'
+        if self.highlight_pin1 == '1':
+            self.highlight_pin1 = 'all'
         self.redraw_on_drag = config.getboolean('html_defaults',
                                                 'redraw_on_drag',
                                                 fallback=not args.no_redraw_on_drag)
-        self.board_rotation = config.getfloat('html_defaults', 'board_rotation',
-                                              fallback=args.board_rotation)
+        self.board_rotation = config.getint(
+            'html_defaults', 'board_rotation',
+            fallback=math.fmod(args.board_rotation // 5, 37))
+        self.offset_back_rotation = config.getboolean(
+            'html_defaults', 'offset_back_rotation',
+            fallback=args.offset_back_rotation)
         self.checkboxes = config.get('html_defaults', 'checkboxes',
                                      fallback=args.checkboxes)
+        self.mark_when_checked = config.get('html_defaults',
+                                            'mark_when_checked',
+                                            fallback=args.mark_when_checked)
         self.bom_view = config.get('html_defaults', 'bom_view',
                                    fallback=args.bom_view)
         self.layer_view = config.get('html_defaults', 'layer_view',
@@ -514,8 +529,9 @@ class Config:
         self.blacklist_virtual = config.getboolean('general',
                                                    'blacklist_virtual',
                                                    fallback=not args.no_blacklist_virtual)
-        self.blacklist_empty_val = config.get('general', 'blacklist_empty_val',
-                                              fallback=args.blacklist_empty_val)
+        self.blacklist_empty_val = config.getboolean(
+            'general', 'blacklist_empty_val',
+            fallback=args.blacklist_empty_val)
         self.include_tracks = config.getboolean('general', 'include_tracks',
                                                 fallback=args.include_tracks)
         self.include_nets = config.getboolean('general', 'include_nets',

--- a/InteractiveHtmlBom/core/config.py
+++ b/InteractiveHtmlBom/core/config.py
@@ -82,7 +82,6 @@ class Config:
     board_variant_whitelist = []
     board_variant_blacklist = []
     dnp_field = ''
-    use_ini = False
 
     # this is cli only field
     kicad_variant = ''
@@ -348,15 +347,27 @@ class Config:
         # Html
         parser.add_argument('--dark-mode', help='Default to dark mode.',
                             action='store_true')
+        parser.add_argument('--no-dark-mode', dest='dark_mode',
+                            help='Do not default to dark mode.',
+                            action='store_false', default=False)
         parser.add_argument('--hide-pads',
                             help='Hide footprint pads by default.',
                             action='store_true')
+        parser.add_argument('--show-pads', dest='hide_pads',
+                            help='Show footprint pads by default.',
+                            action='store_false', default=False)
         parser.add_argument('--show-fabrication',
                             help='Show fabrication layer by default.',
                             action='store_true')
+        parser.add_argument('--hide-fabrication', dest='show_fabrication',
+                            help='Hide fabrication layer by default.',
+                            action='store_false', default=False)
         parser.add_argument('--hide-silkscreen',
                             help='Hide silkscreen by default.',
                             action='store_true')
+        parser.add_argument('--show-silkscreen', dest='hide_silkscreen',
+                            help='Show silkscreen by default.',
+                            action='store_false', default=False)
         parser.add_argument('--highlight-pin1',
                             default=cls.highlight_pin1_choices[0],
                             const=cls.highlight_pin1_choices[1],
@@ -366,6 +377,9 @@ class Config:
         parser.add_argument('--no-redraw-on-drag',
                             help='Do not redraw pcb on drag by default.',
                             action='store_true')
+        parser.add_argument('--redraw-on-drag', dest='no_redraw_on_drag',
+                            help='Redraw pcb on drag by default.',
+                            action='store_false', default=False)
         parser.add_argument('--board-rotation', type=int,
                             default=cls.board_rotation * 5,
                             help='Board rotation in degrees (-180 to 180). '
@@ -373,6 +387,10 @@ class Config:
         parser.add_argument('--offset-back-rotation',
                             help='Offset the back of the pcb by 180 degrees',
                             action='store_true')
+        parser.add_argument('--no-offset-back-rotation',
+                            dest='offset_back_rotation',
+                            help='Do not offset the back of the pcb by 180 degrees',
+                            action='store_false', default=False)
         parser.add_argument('--checkboxes',
                             default=cls.checkboxes,
                             help='Comma separated list of checkbox columns.')
@@ -389,8 +407,14 @@ class Config:
         parser.add_argument('--no-compression',
                             help='Disable compression of pcb data.',
                             action='store_true')
+        parser.add_argument('--compression', dest='no_compression',
+                            help='Enable compression of pcb data.',
+                            action='store_false', default=False)
         parser.add_argument('--no-browser', help='Do not launch browser.',
                             action='store_true')
+        parser.add_argument('--browser', dest='no_browser',
+                            help='Launch browser.',
+                            action='store_false', default=False)
         parser.add_argument('--use-ini', help='Use all run options from ibom ini file.',
                             action='store_true')
 
@@ -403,8 +427,14 @@ class Config:
         parser.add_argument('--include-tracks', action='store_true',
                             help='Include track/zone information in output. '
                                  'F.Cu and B.Cu layers only.')
+        parser.add_argument('--exclude-tracks', dest='include_tracks',
+                           action='store_false', default=False,
+                           help='Exclude track/zone information from output.')
         parser.add_argument('--include-nets', action='store_true',
                             help='Include netlist information in output.')
+        parser.add_argument('--exclude-nets', dest='include_nets',
+                           action='store_false', default=False,
+                           help='Exclude netlist information from output.')
         parser.add_argument('--sort-order',
                             help='Default sort order for components. '
                                  'Must contain "~" once.',
@@ -416,8 +446,15 @@ class Config:
                                  'E.g. "X1,MH*"')
         parser.add_argument('--no-blacklist-virtual', action='store_true',
                             help='Do not blacklist virtual components.')
+        parser.add_argument('--blacklist-virtual', dest='no_blacklist_virtual',
+                            action='store_false', default=False,
+                            help='Blacklist virtual components.')
         parser.add_argument('--blacklist-empty-val', action='store_true',
                             help='Blacklist components with empty value.')
+        parser.add_argument('--no-blacklist-empty-val',
+                            dest='blacklist_empty_val',
+                            action='store_false', default=False,
+                            help='Do not blacklist components with empty value.')
 
         # Fields section
         parser.add_argument('--netlist-file',
@@ -438,6 +475,10 @@ class Config:
                             help='Normalize extra field name case. E.g. "MPN" '
                                  ', "mpn" will be considered the same field.',
                             action='store_true')
+        parser.add_argument('--no-normalize-field-case',
+                            dest='normalize_field_case',
+                            help='Do not normalize extra field name case.',
+                            action='store_false', default=False)
         parser.add_argument('--variant-field',
                             help='Name of the extra field that stores board '
                                  'variant for component.')
@@ -454,120 +495,108 @@ class Config:
                                  'do not populate status. Components with '
                                  'this field not empty will be excluded.')
 
-    def set_from_args_with_ini(self, args, cli_provided=frozenset()):
-        # type: (argparse.Namespace, frozenset) -> None
-        import configparser
-        import sys
+    def get_ini_defaults(self):
+        # type: () -> dict | None
+        """Read the ibom ini file and return its values keyed by the dest
+        of the matching command line option, suitable for passing to
+        ArgumentParser.set_defaults(). Installing the ini values as parser
+        defaults makes options given on the command line override the ini
+        while all other options fall back to the ini values.
 
-        from ..errors import ExitCodes
+        Returns None if no ini file exists in the usual locations.
+        """
+        import configparser
 
         if os.path.isfile(self.local_config_file):
             file = self.local_config_file
         elif os.path.isfile(self.global_config_file):
             file = self.global_config_file
         else:
-            print("Error! No ini file in usual locations")
-            sys.exit(ExitCodes.ERROR_FILE_NOT_FOUND)
+            return None
+        print("Loading options from %s" % file)
 
-        config = configparser.ConfigParser()
-        config.read(file)
+        # Interpolation is disabled because values like bom_name_format
+        # legitimately contain '%'.
+        ini = configparser.ConfigParser(interpolation=None)
+        ini.read(file)
 
-        # Start from the command line arguments (and their defaults). Any option
-        # explicitly passed on the command line takes precedence over the ini
-        # file; the ini only fills in options the user did not specify.
-        self.set_from_args(args)
-
-        # Options that map directly between an ini key and a config attribute.
-        # Each entry is (section, key, attribute, kind, cli_dest); the ini value
-        # is used only when the matching command line option (cli_dest) was not
-        # explicitly provided, otherwise the value from set_from_args is kept.
+        # Each entry is (section, key, dest, kind) mapping an ini key to
+        # the dest of the command line option holding the same setting.
+        # kind describes how the ini value translates to the value argparse
+        # would have produced for that dest:
+        #   'bool': same boolean
+        #   'not' : inverted boolean (the ini stores the positive setting,
+        #           the option's dest stores the negated one)
+        #   'str' : verbatim string; comma separated lists stay joined,
+        #           set_from_args splits them
+        # board_rotation is handled separately below. extra_data_file is
+        # intentionally not read from the ini; it is chosen dynamically
+        # unless given on the command line.
         ini_options = [
             # Html
-            ('html_defaults', 'dark_mode', 'dark_mode', 'bool', 'dark_mode'),
-            ('html_defaults', 'show_pads', 'show_pads', 'bool', 'hide_pads'),
-            ('html_defaults', 'show_fabrication', 'show_fabrication', 'bool',
-             'show_fabrication'),
-            ('html_defaults', 'show_silkscreen', 'show_silkscreen', 'bool',
-             'hide_silkscreen'),
-            ('html_defaults', 'highlight_pin1', 'highlight_pin1', 'str',
-             'highlight_pin1'),
-            ('html_defaults', 'redraw_on_drag', 'redraw_on_drag', 'bool',
-             'no_redraw_on_drag'),
-            ('html_defaults', 'board_rotation', 'board_rotation', 'int',
-             'board_rotation'),
+            ('html_defaults', 'dark_mode', 'dark_mode', 'bool'),
+            ('html_defaults', 'show_pads', 'hide_pads', 'not'),
+            ('html_defaults', 'show_fabrication', 'show_fabrication',
+             'bool'),
+            ('html_defaults', 'show_silkscreen', 'hide_silkscreen', 'not'),
+            ('html_defaults', 'highlight_pin1', 'highlight_pin1', 'str'),
+            ('html_defaults', 'redraw_on_drag', 'no_redraw_on_drag', 'not'),
             ('html_defaults', 'offset_back_rotation', 'offset_back_rotation',
-             'bool', 'offset_back_rotation'),
-            ('html_defaults', 'checkboxes', 'checkboxes', 'str', 'checkboxes'),
-            ('html_defaults', 'mark_when_checked', 'mark_when_checked', 'str',
-             'mark_when_checked'),
-            ('html_defaults', 'bom_view', 'bom_view', 'str', 'bom_view'),
-            ('html_defaults', 'layer_view', 'layer_view', 'str', 'layer_view'),
-            ('html_defaults', 'compression', 'compression', 'bool',
-             'no_compression'),
-            ('html_defaults', 'open_browser', 'open_browser', 'bool',
-             'no_browser'),
+             'bool'),
+            ('html_defaults', 'checkboxes', 'checkboxes', 'str'),
+            ('html_defaults', 'mark_when_checked', 'mark_when_checked',
+             'str'),
+            ('html_defaults', 'bom_view', 'bom_view', 'str'),
+            ('html_defaults', 'layer_view', 'layer_view', 'str'),
+            ('html_defaults', 'compression', 'no_compression', 'not'),
+            ('html_defaults', 'open_browser', 'no_browser', 'not'),
             # General
-            ('general', 'bom_dest_dir', 'bom_dest_dir', 'str', 'dest_dir'),
-            ('general', 'bom_name_format', 'bom_name_format', 'str',
-             'name_format'),
-            ('general', 'component_sort_order', 'component_sort_order', 'list',
-             'sort_order'),
-            ('general', 'component_blacklist', 'component_blacklist', 'list',
-             'blacklist'),
-            ('general', 'blacklist_virtual', 'blacklist_virtual', 'bool',
-             'no_blacklist_virtual'),
-            ('general', 'blacklist_empty_val', 'blacklist_empty_val', 'bool',
-             'blacklist_empty_val'),
-            ('general', 'include_tracks', 'include_tracks', 'bool',
-             'include_tracks'),
-            ('general', 'include_nets', 'include_nets', 'bool', 'include_nets'),
-            # Fields (show_fields/group_fields handled separately below)
-            ('fields', 'normalize_field_case', 'normalize_field_case', 'bool',
-             'normalize_field_case'),
-            ('fields', 'board_variant_field', 'board_variant_field', 'str',
-             'variant_field'),
-            ('fields', 'board_variant_whitelist', 'board_variant_whitelist',
-             'list', 'variants_whitelist'),
-            ('fields', 'board_variant_blacklist', 'board_variant_blacklist',
-             'list', 'variants_blacklist'),
-            ('fields', 'dnp_field', 'dnp_field', 'str', 'dnp_field'),
+            ('general', 'bom_dest_dir', 'dest_dir', 'str'),
+            ('general', 'bom_name_format', 'name_format', 'str'),
+            ('general', 'component_sort_order', 'sort_order', 'str'),
+            ('general', 'component_blacklist', 'blacklist', 'str'),
+            ('general', 'blacklist_virtual', 'no_blacklist_virtual', 'not'),
+            ('general', 'blacklist_empty_val', 'blacklist_empty_val',
+             'bool'),
+            ('general', 'include_tracks', 'include_tracks', 'bool'),
+            ('general', 'include_nets', 'include_nets', 'bool'),
+            # Fields
+            ('fields', 'show_fields', 'show_fields', 'str'),
+            ('fields', 'group_fields', 'group_fields', 'str'),
+            ('fields', 'normalize_field_case', 'normalize_field_case',
+             'bool'),
+            ('fields', 'board_variant_field', 'variant_field', 'str'),
+            ('fields', 'board_variant_whitelist', 'variants_whitelist',
+             'str'),
+            ('fields', 'board_variant_blacklist', 'variants_blacklist',
+             'str'),
+            ('fields', 'dnp_field', 'dnp_field', 'str'),
         ]
 
-        getters = {
-            'bool': config.getboolean,
-            'int': config.getint,
-            'str': config.get,
-        }
-        for section, key, attr, kind, dest in ini_options:
-            if dest in cli_provided:
+        defaults = {}
+        for section, key, dest, kind in ini_options:
+            if not ini.has_option(section, key):
                 continue
-            current = getattr(self, attr)
-            if kind == 'list':
-                value = self._split(
-                    config.get(section, key, fallback=self._join(current)))
+            if kind == 'bool':
+                defaults[dest] = ini.getboolean(section, key)
+            elif kind == 'not':
+                defaults[dest] = not ini.getboolean(section, key)
             else:
-                value = getters[kind](section, key, fallback=current)
-            setattr(self, attr, value)
+                defaults[dest] = ini.get(section, key)
+
+        # The ini stores rotation in multiples of 5 degrees, the command
+        # line option takes degrees.
+        if ini.has_option('html_defaults', 'board_rotation'):
+            defaults['board_rotation'] = \
+                ini.getint('html_defaults', 'board_rotation') * 5
 
         # migration from previous settings
-        if self.highlight_pin1 == '0':
-            self.highlight_pin1 = 'none'
-        if self.highlight_pin1 == '1':
-            self.highlight_pin1 = 'all'
+        if defaults.get('highlight_pin1') == '0':
+            defaults['highlight_pin1'] = 'none'
+        if defaults.get('highlight_pin1') == '1':
+            defaults['highlight_pin1'] = 'all'
 
-        # extra_data_file is intentionally not read from the ini; it is chosen
-        # dynamically unless explicitly given on the command line.
-        # show_fields/group_fields come from the ini only when the user did not
-        # override them (or --extra-fields) on the command line.
-        if 'extra_fields' not in cli_provided:
-            if 'show_fields' not in cli_provided:
-                self.show_fields = self._split(config.get(
-                    'fields', 'show_fields',
-                    fallback=self._join(self.show_fields)))
-            if 'group_fields' not in cli_provided:
-                self.group_fields = self._split(config.get(
-                    'fields', 'group_fields',
-                    fallback=self._join(self.group_fields)))
+        return defaults
 
     def set_from_args(self, args):
         # type: (argparse.Namespace) -> None

--- a/InteractiveHtmlBom/generate_interactive_bom.py
+++ b/InteractiveHtmlBom/generate_interactive_bom.py
@@ -81,7 +81,10 @@ def main():
         except ParsingException as e:
             exit_error(logger, ExitCodes.ERROR_PARSE, e)
     else:
-        config.set_from_args(args)
+        if args.use_ini:
+            config.set_from_args_with_ini(args)
+        else:
+            config.set_from_args(args)
         try:
             ibom.main(parser, config, logger)
         except ParsingException as e:

--- a/InteractiveHtmlBom/generate_interactive_bom.py
+++ b/InteractiveHtmlBom/generate_interactive_bom.py
@@ -56,21 +56,33 @@ def main():
                         help="KiCad PCB file")
 
     Config.add_options(parser, version)
-    args = parser.parse_args()
-    # Options explicitly provided on the command line (i.e. those that differ
-    # from their argparse default). Used so that CLI options take precedence
-    # over values loaded from the ini file.
-    cli_provided = frozenset(
-        k for k in vars(args) if getattr(args, k) != parser.get_default(k))
     logger = ibom.Logger(cli=True)
 
-    if not os.path.isfile(args.file):
+    # First pass over the arguments to find the pcb file and --use-ini.
+    pre_args, _ = parser.parse_known_args()
+
+    if not os.path.isfile(pre_args.file):
         exit_error(logger, ExitCodes.ERROR_FILE_NOT_FOUND,
-                   "File %s does not exist." % args.file)
+                   "File %s does not exist." % pre_args.file)
+
+    config = Config(version,
+                    os.path.dirname(os.path.abspath(pre_args.file)))
+
+    # With --use-ini the ini values are installed as parser defaults before
+    # the final parse: options given on the command line override the ini
+    # while all other options fall back to the ini values.
+    if pre_args.use_ini and not pre_args.show_dialog:
+        ini_defaults = config.get_ini_defaults()
+        if ini_defaults is None:
+            exit_error(logger, ExitCodes.ERROR_FILE_NOT_FOUND,
+                       "No ibom ini file found in usual locations.")
+        else:
+            parser.set_defaults(**ini_defaults)
+
+    args = parser.parse_args()
 
     print("Loading %s" % args.file)
 
-    config = Config(version, os.path.dirname(os.path.abspath(args.file)))
     config.kicad_variant = args.kicad_variant
 
     parser = get_parser_by_extension(
@@ -86,10 +98,7 @@ def main():
         except ParsingException as e:
             exit_error(logger, ExitCodes.ERROR_PARSE, e)
     else:
-        if args.use_ini:
-            config.set_from_args_with_ini(args, cli_provided)
-        else:
-            config.set_from_args(args)
+        config.set_from_args(args)
         try:
             ibom.main(parser, config, logger)
         except ParsingException as e:

--- a/InteractiveHtmlBom/generate_interactive_bom.py
+++ b/InteractiveHtmlBom/generate_interactive_bom.py
@@ -57,6 +57,11 @@ def main():
 
     Config.add_options(parser, version)
     args = parser.parse_args()
+    # Options explicitly provided on the command line (i.e. those that differ
+    # from their argparse default). Used so that CLI options take precedence
+    # over values loaded from the ini file.
+    cli_provided = frozenset(
+        k for k in vars(args) if getattr(args, k) != parser.get_default(k))
     logger = ibom.Logger(cli=True)
 
     if not os.path.isfile(args.file):
@@ -82,7 +87,7 @@ def main():
             exit_error(logger, ExitCodes.ERROR_PARSE, e)
     else:
         if args.use_ini:
-            config.set_from_args_with_ini(args)
+            config.set_from_args_with_ini(args, cli_provided)
         else:
             config.set_from_args(args)
         try:


### PR DESCRIPTION
This pull request adds support for loading configuration options from an ini file via a new `--use-ini` command-line argument.

**New ini-based configuration loading:**

* Added a `use_ini` attribute to the `Config` class and a corresponding `--use-ini` command-line argument to enable reading options from an ini file. [[1]](diffhunk://#diff-d107983e11f1e8087067a31f6e26934ac453937c5b5d37c3fb5a027de6398528R85) [[2]](diffhunk://#diff-d107983e11f1e8087067a31f6e26934ac453937c5b5d37c3fb5a027de6398528R394-R395)
* Implemented the `set_from_args_with_ini` method in `Config` to load configuration values from either a local or global ini file, with fallback to command-line arguments when options are missing.
* Updated the main entry point (`generate_interactive_bom.py`) to call `set_from_args_with_ini` when `--use-ini` is specified.

Supersedes #432 

Maybe handles #368