### PR TITLE
Fix column-visibility dropdown closing after every click

### DIFF
--- a/InteractiveHtmlBom/web/ibom.css
+++ b/InteractiveHtmlBom/web/ibom.css
@@ -250,6 +250,9 @@ canvas:active {
 
 .bom .numCol {
   width: 30px;
+  /* Pinned so a re-wrapped header label, which changes the row height, cannot
+     shift the open column visibility dropdown. */
+  vertical-align: top;
 }
 
 .bom .value {

--- a/InteractiveHtmlBom/web/ibom.js
+++ b/InteractiveHtmlBom/web/ibom.js
@@ -478,84 +478,137 @@ function createColumnHeader(name, cls, comparator, is_checkbox = false) {
   return th;
 }
 
-// Cached across populateBomHeader() calls so toggling a column's visibility
-// doesn't recreate this element - a fresh element never has the browser's
-// :hover state applied to it, so the CSS-only dropdown would instantly
-// close after every click.
-var visMenuElement = null;
+// The dropdown is opened by CSS (`.menu:hover .menu-content`) and :hover is lost
+// when an element leaves the document, so the header row, its numCol cell and the
+// menu are kept across rebuilds instead of being recreated. See issue #254.
+var bomHeaderRow = null;
+var visMenu = null;
+var visMenuContent = null;
+var visMenuColumns = null;
 
-function getVisMenu() {
-  if (!visMenuElement) {
-    visMenuElement = document.createElement("div");
-    visMenuElement.id = "vismenu";
-    visMenuElement.classList.add("menu");
+function getVisMenuColumns() {
+  return settings.columnOrder.filter(column => {
+    if (typeof column !== "string")
+      return false;
+
+    // Skip empty columns
+    if (column === "checkboxes" && settings.checkboxes.length == 0)
+      return false;
+    else if (column === "Quantity" && settings.bommode == "ungrouped")
+      return false;
+
+    return true;
+  });
+}
+
+function createVisMenuLabel(column) {
+  var label = document.createElement("label");
+  label.classList.add("menu-label");
+
+  var input = document.createElement("input");
+  input.classList.add("visibility_checkbox");
+  input.type = "checkbox";
+  input.onchange = function (e) {
+    setShowBOMColumn(column, e.target.checked)
+  };
+  input.checked = !(settings.hiddenColumns.includes(column));
+  // Set explicitly because changeBomMode() cannot re-enable these once the menu
+  // has been detached.
+  input.disabled = false;
+
+  label.appendChild(input);
+  if (column.length > 0)
+    label.append(column[0].toUpperCase() + column.slice(1));
+
+  return label;
+}
+
+function populateVisMenu() {
+  var columns = getVisMenuColumns();
+  var sameColumns = visMenuColumns !== null &&
+    visMenuColumns.length == columns.length &&
+    visMenuColumns.every((column, i) => column === columns[i]);
+
+  if (sameColumns) {
+    // Leave the DOM alone so the element under the cursor stays alive.
+    columns.forEach((column, i) => {
+      var input = visMenuContent.children[i].firstChild;
+      input.checked = !(settings.hiddenColumns.includes(column));
+      input.disabled = false;
+    });
+    return;
+  }
+
+  while (visMenuContent.firstChild) {
+    visMenuContent.removeChild(visMenuContent.firstChild);
+  }
+  columns.forEach(column => {
+    visMenuContent.appendChild(createVisMenuLabel(column));
+  });
+  if (visMenuContent.firstChild) {
+    visMenuContent.firstChild.classList.add("menu-label-top");
+  }
+  visMenuColumns = columns;
+}
+
+function getBomHeaderRow() {
+  if (bomHeaderRow === null) {
+    bomHeaderRow = document.createElement("TR");
+
+    var th = document.createElement("TH");
+    th.classList.add("numCol");
+    bomHeaderRow.appendChild(th);
+
+    visMenu = document.createElement("div");
+    visMenu.id = "vismenu";
+    visMenu.classList.add("menu");
 
     var visbutton = document.createElement("div");
     visbutton.classList.add("visbtn");
     visbutton.classList.add("hideonprint");
-    visMenuElement.appendChild(visbutton);
+    visMenu.appendChild(visbutton);
+
+    visMenuContent = document.createElement("div");
+    visMenuContent.classList.add("menu-content");
+    visMenuContent.id = "vismenu-content";
+    visMenu.appendChild(visMenuContent);
   }
 
-  // Query within visMenuElement itself (not document.getElementById): by the
-  // time this runs, the header row that used to hold this element has
-  // already been detached from the document, so a document-wide lookup
-  // would miss it and leave stale content behind.
-  var oldContent = visMenuElement.querySelector("#vismenu-content");
-  if (oldContent) {
-    visMenuElement.removeChild(oldContent);
-  }
-
-  var viscontent = document.createElement("div");
-  viscontent.classList.add("menu-content");
-  viscontent.id = "vismenu-content";
-
-  settings.columnOrder.forEach(column => {
-    if (typeof column !== "string")
-      return;
-
-    // Skip empty columns
-    if (column === "checkboxes" && settings.checkboxes.length == 0)
-      return;
-    else if (column === "Quantity" && settings.bommode == "ungrouped")
-      return;
-
-    var label = document.createElement("label");
-    label.classList.add("menu-label");
-
-    var input = document.createElement("input");
-    input.classList.add("visibility_checkbox");
-    input.type = "checkbox";
-    input.onchange = function (e) {
-      setShowBOMColumn(column, e.target.checked)
-    };
-    input.checked = !(settings.hiddenColumns.includes(column));
-
-    label.appendChild(input);
-    if (column.length > 0)
-      label.append(column[0].toUpperCase() + column.slice(1));
-
-    viscontent.appendChild(label);
+  // The row has to be bomhead's only child, because saveBomTable() reads the
+  // header names out of bomhead.childNodes[0].
+  Array.from(bomhead.childNodes).forEach(node => {
+    if (node !== bomHeaderRow)
+      bomhead.removeChild(node);
   });
 
-  viscontent.childNodes[0].classList.add("menu-label-top");
-
-  if (settings.bommode != "netlist") {
-    visMenuElement.appendChild(viscontent);
+  // Guarded because reattaching an attached node detaches it first.
+  if (bomHeaderRow.parentElement !== bomhead) {
+    bomhead.appendChild(bomHeaderRow);
   }
 
-  return visMenuElement;
+  // Drop the column headers, keeping the numCol cell and the menu it holds.
+  while (bomHeaderRow.children.length > 1) {
+    bomHeaderRow.removeChild(bomHeaderRow.lastChild);
+  }
+
+  var numCol = bomHeaderRow.firstElementChild;
+  if (settings.bommode == "netlist") {
+    // Netlist mode has no configurable columns, so there is no menu to show.
+    if (visMenu.parentElement === numCol) {
+      numCol.removeChild(visMenu);
+    }
+  } else {
+    populateVisMenu();
+    if (visMenu.parentElement !== numCol) {
+      numCol.appendChild(visMenu);
+    }
+  }
+
+  return bomHeaderRow;
 }
 
 function populateBomHeader(placeHolderColumn = null, placeHolderElements = null) {
-  while (bomhead.firstChild) {
-    bomhead.removeChild(bomhead.firstChild);
-  }
-  var tr = document.createElement("TR");
-  var th = document.createElement("TH");
-  th.classList.add("numCol");
-
-  th.appendChild(getVisMenu());
-  tr.appendChild(th);
+  var tr = getBomHeaderRow();
 
   var checkboxCompareClosure = function (checkbox) {
     return (a, b) => {
@@ -617,7 +670,7 @@ function populateBomHeader(placeHolderColumn = null, placeHolderElements = null)
         return;
       } else if (column === "checkboxes") {
         for (var checkbox of settings.checkboxes) {
-          th = createColumnHeader(
+          var th = createColumnHeader(
             checkbox, "bom-checkbox", checkboxCompareClosure(checkbox), true);
           tr.appendChild(th);
         }
@@ -655,7 +708,6 @@ function populateBomHeader(placeHolderColumn = null, placeHolderElements = null)
       }
     });
   }
-  bomhead.appendChild(tr);
 }
 
 function populateBomBody(placeholderColumn = null, placeHolderElements = null) {

--- a/InteractiveHtmlBom/web/ibom.js
+++ b/InteractiveHtmlBom/web/ibom.js
@@ -478,21 +478,32 @@ function createColumnHeader(name, cls, comparator, is_checkbox = false) {
   return th;
 }
 
-function populateBomHeader(placeHolderColumn = null, placeHolderElements = null) {
-  while (bomhead.firstChild) {
-    bomhead.removeChild(bomhead.firstChild);
+// Cached across populateBomHeader() calls so toggling a column's visibility
+// doesn't recreate this element - a fresh element never has the browser's
+// :hover state applied to it, so the CSS-only dropdown would instantly
+// close after every click.
+var visMenuElement = null;
+
+function getVisMenu() {
+  if (!visMenuElement) {
+    visMenuElement = document.createElement("div");
+    visMenuElement.id = "vismenu";
+    visMenuElement.classList.add("menu");
+
+    var visbutton = document.createElement("div");
+    visbutton.classList.add("visbtn");
+    visbutton.classList.add("hideonprint");
+    visMenuElement.appendChild(visbutton);
   }
-  var tr = document.createElement("TR");
-  var th = document.createElement("TH");
-  th.classList.add("numCol");
 
-  var vismenu = document.createElement("div");
-  vismenu.id = "vismenu";
-  vismenu.classList.add("menu");
-
-  var visbutton = document.createElement("div");
-  visbutton.classList.add("visbtn");
-  visbutton.classList.add("hideonprint");
+  // Query within visMenuElement itself (not document.getElementById): by the
+  // time this runs, the header row that used to hold this element has
+  // already been detached from the document, so a document-wide lookup
+  // would miss it and leave stale content behind.
+  var oldContent = visMenuElement.querySelector("#vismenu-content");
+  if (oldContent) {
+    visMenuElement.removeChild(oldContent);
+  }
 
   var viscontent = document.createElement("div");
   viscontent.classList.add("menu-content");
@@ -528,11 +539,22 @@ function populateBomHeader(placeHolderColumn = null, placeHolderElements = null)
 
   viscontent.childNodes[0].classList.add("menu-label-top");
 
-  vismenu.appendChild(visbutton);
   if (settings.bommode != "netlist") {
-    vismenu.appendChild(viscontent);
-    th.appendChild(vismenu);
+    visMenuElement.appendChild(viscontent);
   }
+
+  return visMenuElement;
+}
+
+function populateBomHeader(placeHolderColumn = null, placeHolderElements = null) {
+  while (bomhead.firstChild) {
+    bomhead.removeChild(bomhead.firstChild);
+  }
+  var tr = document.createElement("TR");
+  var th = document.createElement("TH");
+  th.classList.add("numCol");
+
+  th.appendChild(getVisMenu());
   tr.appendChild(th);
 
   var checkboxCompareClosure = function (checkbox) {


### PR DESCRIPTION
Fixes #254

`populateBomHeader()` tore down and rebuilt the entire header row,
including the column-visibility menu, on every checkbox toggle. The
menu's open/closed state is CSS-only (`.menu:hover .menu-content`),
and a freshly created element never has the browser's `:hover` state
applied to it, so the dropdown closed immediately after each click
even though the cursor never moved.

Extracted the menu into `getVisMenu()`, which reuses the same DOM
element across rebuilds instead of recreating it, preserving its
hover state while still refreshing the checkbox list and checked
states.

Verified by repeated checkbox toggles: the menu element's identity
stays stable and the dropdown content doesn't duplicate or leak
across rebuilds.