### PR TITLE
Add support for KiCad 10 native barcodes/QR codes

### DIFF
--- a/InteractiveHtmlBom/ecad/kicad.py
+++ b/InteractiveHtmlBom/ecad/kicad.py
@@ -378,6 +378,21 @@ class PcbnewParser(EcadParser):
             "svgpath": svgpath
         }
 
+    def parse_barcode(self, d):
+        # type: (pcbnew.BOARD_ITEM) -> dict
+        if hasattr(d, "GetPolyShape"):
+            polygons = self.parse_poly_set(d.GetPolyShape())
+            if not polygons:
+                return None
+            return {
+                "type": "polygon",
+                "pos": [0, 0],
+                "angle": 0,
+                "polygons": polygons,
+                "filled": 1,
+            }
+        return None
+
     def parse_drawing(self, d):
         # type: (pcbnew.BOARD_ITEM) -> list
         result = []
@@ -393,6 +408,8 @@ class PcbnewParser(EcadParser):
                 s = self.parse_text(d.Text())
             else:
                 s = self.parse_text(d)
+        elif d.GetClass() in ["BARCODE", "PCB_BARCODE"]:
+            s = self.parse_barcode(d)
         else:
             self.logger.info("Unsupported drawing class %s, skipping",
                              d.GetClass())


### PR DESCRIPTION
KiCad 10 introduced native barcode and QR code objects (`BARCODE`/`PCB_BARCODE`), but `InteractiveHtmlBom` currently skips them and logs an unsupported drawing class warning. This PR updates `PcbnewParser` to extract their polygon data so they render correctly in the HTML output. I've tested this by placing a native barcode and QR code on the silkscreen layer and verifying it appears perfectly in the generated BOM.

<img width="550" alt="image" src="https://github.com/user-attachments/assets/ee8c7dc4-8d35-4cff-a792-360c57ceff7b" />
