### PR TITLE
Add support for native KiCad knockout text

### DIFF
--- a/InteractiveHtmlBom/ecad/kicad.py
+++ b/InteractiveHtmlBom/ecad/kicad.py
@@ -282,7 +282,8 @@ class PcbnewParser(EcadParser):
         if (hasattr(d, "IsKnockout") and d.IsKnockout()
                 and hasattr(d, "GetEffectiveShape")):
             shape = d.GetEffectiveShape()
-            if (shape and hasattr(pcbnew, "SH_POLY_SET")
+            if (shape and hasattr(shape, "Cast")
+                    and hasattr(pcbnew, "SH_POLY_SET")
                     and shape.Type() == pcbnew.SH_POLY_SET):
                 polygons = self.parse_poly_set(shape.Cast())
                 if polygons:

--- a/InteractiveHtmlBom/ecad/kicad.py
+++ b/InteractiveHtmlBom/ecad/kicad.py
@@ -269,6 +269,9 @@ class PcbnewParser(EcadParser):
 
         for i in range(poly.OutlineCount()):
             result.append(self.parse_line_chain(poly.Outline(i)))
+            if hasattr(poly, "HoleCount"):
+                for j in range(poly.HoleCount(i)):
+                    result.append(self.parse_line_chain(poly.Hole(i, j)))
 
         return result
 
@@ -276,6 +279,16 @@ class PcbnewParser(EcadParser):
         # type: (pcbnew.PCB_TEXT) -> dict
         if not d.IsVisible() and d.GetClass() not in ["PTEXT", "PCB_TEXT"]:
             return None
+        if (hasattr(d, "IsKnockout") and d.IsKnockout()
+                and hasattr(d, "GetEffectiveShape")):
+            shape = d.GetEffectiveShape()
+            if (shape and hasattr(pcbnew, "SH_POLY_SET")
+                    and shape.Type() == pcbnew.SH_POLY_SET):
+                polygons = self.parse_poly_set(shape.Cast())
+                if polygons:
+                    return {
+                        "polygons": polygons
+                    }
         pos = self.normalize(d.GetPosition())
         if hasattr(d, "GetTextThickness"):
             thickness = d.GetTextThickness() * 1e-6


### PR DESCRIPTION
KiCad 7+ supports "knockout" text, but `InteractiveHtmlBom` currently ignores the background box and renders it as standard text. This PR updates `parse_text()` and `parse_poly_set()` to extract the proper polygon shapes and hole loops when `IsKnockout()` is active/true. I've tested this with knockout text on the silkscreen layer and verified that the background box renders with the characters cleanly cut out in the generated HTML BOM.

<img width="650" alt="image" src="https://github.com/user-attachments/assets/87f4a07f-b23f-4cd8-9739-9f478b3b6ef6" />
<img width="650" alt="image" src="https://github.com/user-attachments/assets/63a460b9-be6f-4728-a682-19eeaff6f1f0" />
